### PR TITLE
Bootstrap command for creating ThirdPartyResources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ RUN apk --no-cache add git
 RUN go get ./...
 RUN go build -o kubeac cmd/kubeac/main.go
 RUN go build -o wrap cmd/wrap/main.go
+RUN go build -o bootstrap cmd/bootstrap/main.go
 RUN mv kubeac /usr/bin/kubeac
 RUN mv wrap /usr/bin/wrap
+RUN mv bootstrap /usr/bin/bootstrap
 
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk --no-cache add runit@community

--- a/client/client.go
+++ b/client/client.go
@@ -79,10 +79,9 @@ func newForConfig(c restclient.Config) (Interface, error) {
 	}, nil
 }
 
-func New(url string) (Interface, error) {
-	var rc *restclient.Config
-	var err error
-
+// GetConfig returns restclient.Config for given URL.
+// If url is empty, assume in-cluster config. Otherwise, return config for remote cluster.
+func GetConfig(url string) (rc *restclient.Config, err error) {
 	if url == "" {
 		log.Println("No Kubernetes cluster URL provided. Assume in-cluster.")
 		rc, err = restclient.InClusterConfig()
@@ -94,6 +93,13 @@ func New(url string) (Interface, error) {
 			Host: url,
 		}
 	}
+	return
+}
 
+func New(url string) (Interface, error) {
+	rc, err := GetConfig(url)
+	if err != nil {
+		return nil, err
+	}
 	return newForConfig(*rc)
 }

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -1,0 +1,84 @@
+// Copyright 2016 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"log"
+	"os"
+
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/Mirantis/k8s-AppController/client"
+)
+
+func getFileContents(stream *os.File) string {
+	result := ""
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		result += scanner.Text() + "\n"
+	}
+	return result
+}
+
+func createTPRIfNotExists(tpr extensions.ThirdPartyResource, client unversioned.Client) {
+	_, err := client.Extensions().ThirdPartyResources().Create(&tpr)
+	if err != nil {
+		e := err.(*errors.StatusError)
+		if e.ErrStatus.Code != 409 {
+			log.Fatal(err)
+		} else {
+			log.Printf("%s already exists, skipping", e.ErrStatus.Details.Name)
+		}
+	} else {
+		log.Printf("Created %s", tpr.ObjectMeta.Name)
+	}
+	return
+}
+
+func getDependencyFromPath(path string) extensions.ThirdPartyResource {
+	file, err := os.Open(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var tpr extensions.ThirdPartyResource
+	err = json.Unmarshal([]byte(getFileContents(file)), &tpr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return tpr
+}
+
+func main() {
+	thirdPartyResourcesPath := os.Args[1]
+
+	dependencyTPR := getDependencyFromPath(thirdPartyResourcesPath + "/dependencies.json")
+	definitionTPR := getDependencyFromPath(thirdPartyResourcesPath + "/resdefs.json")
+
+	url := os.Getenv("KUBERNETES_CLUSTER_URL")
+	config, err := client.GetConfig(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	c := *unversioned.NewOrDie(config)
+
+	createTPRIfNotExists(dependencyTPR, c)
+	createTPRIfNotExists(definitionTPR, c)
+}

--- a/examples/extended/create.sh
+++ b/examples/extended/create.sh
@@ -4,8 +4,6 @@
 kubectl.sh create -f existing_job.yaml
 
 kubectl.sh create -f ../../manifests/appcontroller.yaml
-kubectl.sh create -f ../../manifests/dependencies.yaml
-kubectl.sh create -f ../../manifests/resdefs.yaml
 
 sleep 10
 

--- a/examples/simple/create.sh
+++ b/examples/simple/create.sh
@@ -9,11 +9,6 @@ kubectl.sh create -f existing_job.yaml
 echo "Creating pod with AppController binary. This is going to be our entry point."
 echo "kubectl.sh create -f ../../appcontroller.yaml"
 kubectl.sh create -f ../../manifests/appcontroller.yaml
-echo "Creating ThirdPartyResources - basically we are creating new k8s API endpoints so that we can store Resource Definitions and Dependencies in Kubernetes cluster."
-echo "kubectl.sh create -f ../../manifests/dependencies.yaml"
-kubectl.sh create -f ../../manifests/dependencies.yaml
-echo "kubectl.sh create -f ../../manifests/resdefs.yaml"
-kubectl.sh create -f ../../manifests/resdefs.yaml
 
 echo "Wait for cluster to register new endpoints and run appcontroller container"
 sleep 10

--- a/manifests/appcontroller.yaml
+++ b/manifests/appcontroller.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: k8s-appcontroller
+  annotations:
+    pod.alpha.kubernetes.io/init-containers: '[{"name": "kubeac-bootstrap", "image": "mirantis/k8s-appcontroller", "command": ["bootstrap", "/go/src/github.com/Mirantis/k8s-AppController/manifests"]}]'
 spec:
   restartPolicy: Always
   containers:

--- a/manifests/dependencies.json
+++ b/manifests/dependencies.json
@@ -1,0 +1,13 @@
+{
+	"metadata": {
+		"name": "dependency.appcontroller.k8s1"
+	},
+	"apiVersion": "extensions/v1beta1",
+	"kind": "ThirdPartyResource",
+	"description": "Dependencies for App Controller resources",
+	"versions": [
+		{
+			"name": "v1alpha1"
+		}
+	]
+}

--- a/manifests/dependencies.yaml
+++ b/manifests/dependencies.yaml
@@ -1,7 +1,0 @@
-metadata:
-  name: dependency.appcontroller.k8s1
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-description: "Dependencies for App Controller resources"
-versions:
-- name: v1alpha1

--- a/manifests/resdefs.json
+++ b/manifests/resdefs.json
@@ -1,0 +1,13 @@
+{
+	"metadata": {
+		"name": "definition.appcontroller.k8s2"
+	},
+	"apiVersion": "extensions/v1beta1",
+	"kind": "ThirdPartyResource",
+	"description": "Resource definitions for App Controller",
+	"versions": [
+		{
+			"name": "v1alpha1"
+		}
+	]
+}

--- a/manifests/resdefs.yaml
+++ b/manifests/resdefs.yaml
@@ -1,7 +1,0 @@
-metadata:
-  name: definition.appcontroller.k8s2
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-description: "Resource definitions for App Controller"
-versions:
-- name: v1alpha1


### PR DESCRIPTION
The command is a go binary, which creates ThirdPartyResources.

It is added to AppController image.

AppController pod is given initcontainer which runs the binary.

ThirdPartyResource manifests moved to json files due to unmarshalling
problems

If the ThirdPartyResources already exist in cluster - don't do anything