### PR TITLE
Remove /go directory to save some space (~800MB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,6 @@ ADD run_runit.sh /usr/bin/run_runit
 ADD ac-run.sh /usr/bin/ac-run
 ADD ac-stop.sh /usr/bin/ac-stop
 RUN touch /etc/sv/ac/down
+
+# shrink size
+RUN rm -fr /go


### PR DESCRIPTION
Remove /go after everything is build. It saves more than 800MB on image size.