### PR TITLE
Use more standard directories.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /go/src/github.com/Mirantis/k8s-AppController
 WORKDIR /go/src/github.com/Mirantis/k8s-AppController
 
 RUN apk --no-cache add git
-RUN go get ./... && go build -o kubeac cmd/kubeac/main.go && go build -o wrap cmd/wrap/main.go && go build -o bootstrap cmd/bootstrap/main.go && mv kubeac /usr/bin/kubeac && mv wrap /usr/bin/wrap && mv bootstrap /usr/bin/bootstrap && mv /go/src/github.com/Mirantis/k8s-AppController/manifests /manifests && rm -fr /go
+RUN go get ./... && go build -o kubeac cmd/kubeac/main.go && go build -o wrap cmd/wrap/main.go && go build -o bootstrap cmd/bootstrap/main.go && mv kubeac /usr/bin/kubeac && mv wrap /usr/bin/wrap && mv bootstrap /usr/bin/bootstrap && mkdir -p /opt/kubeac && mv /go/src/github.com/Mirantis/k8s-AppController/manifests /opt/kubeac/manifests && rm -fr /go
 
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk --no-cache add runit@community

--- a/manifests/appcontroller.yaml
+++ b/manifests/appcontroller.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: k8s-appcontroller
   annotations:
-    pod.alpha.kubernetes.io/init-containers: '[{"name": "kubeac-bootstrap", "image": "mirantis/k8s-appcontroller", "command": ["bootstrap", "/manifests"]}]'
+    pod.alpha.kubernetes.io/init-containers: '[{"name": "kubeac-bootstrap", "image": "mirantis/k8s-appcontroller", "command": ["bootstrap", "/opt/kubeac/manifests"]}]'
 spec:
   restartPolicy: Always
   containers:


### PR DESCRIPTION
Other possibility would be to use `/usr/share/kubeac`, but `/opt` seems also ok for things distributed in binary form.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/60)
<!-- Reviewable:end -->
