### PR TITLE
wrap: Refactor and provide JSON format

### DIFF
--- a/cmd/wrap/format/format.go
+++ b/cmd/wrap/format/format.go
@@ -12,37 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package format
 
-import (
-	"bufio"
-	"fmt"
-	"os"
-	"strings"
-
-	"github.com/Mirantis/k8s-AppController/cmd/wrap/format"
-)
-
-func getInput(stream *os.File, indent int) string {
-	result := ""
-	spaces := strings.Repeat(" ", indent)
-
-	scanner := bufio.NewScanner(stream)
-	for scanner.Scan() {
-		// add spaces for identation
-		result += spaces + scanner.Text() + "\n"
-	}
-	return result
+type Format interface {
+	ExtractKind(k8sObject string) (string, error)
+	Wrap(k8sObject string, name string) (string, error)
+	IndentLevel() int
 }
 
-func main() {
-	f := format.Yaml{}
-
-	definition := getInput(os.Stdin, f.IndentLevel())
-
-	out, err := f.Wrap(definition, os.Args[1])
-	if err != nil {
-		panic(err)
-	}
-	fmt.Print(out)
+type KindExtractor struct {
+	Kind string "kind"
 }

--- a/cmd/wrap/format/json.go
+++ b/cmd/wrap/format/json.go
@@ -1,0 +1,48 @@
+// Copyright 2016 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package format
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type Json struct {
+}
+
+func (f Json) ExtractKind(k8sObject string) (string, error) {
+	var kind KindExtractor
+	err := json.Unmarshal([]byte(k8sObject), &kind)
+	return strings.ToLower(kind.Kind), err
+}
+
+func (f Json) Wrap(k8sObject, name string) (string, error) {
+	base := `{
+    "apiVersion": "appcontroller.k8s2/v1alpha1",
+    "kind": "Definition",
+    "metadata": {
+        "name": "` + name + `"
+    },` + "\n"
+
+	kind, err := f.ExtractKind(k8sObject)
+	if err != nil {
+		return "", err
+	}
+	return base + `    "` + kind + `": ` + strings.TrimLeft(k8sObject, " ") + "}\n", nil
+}
+
+func (f Json) IndentLevel() int {
+	return 4
+}

--- a/cmd/wrap/format/json_test.go
+++ b/cmd/wrap/format/json_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package format
+
+import (
+	"testing"
+)
+
+func TestKindJson(t *testing.T) {
+	f := Json{}
+	text := `{"kind": "Job"}`
+	kind, err := f.ExtractKind(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kind != "job" {
+		t.Errorf("Extracted kind should be \"job\", is %s", kind)
+	}
+}
+
+func TestWrapJson(t *testing.T) {
+	f := Json{}
+	text := `{"kind": "Job"}` + "\n"
+
+	wrapped, err := f.Wrap(text, "name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `{
+    "apiVersion": "appcontroller.k8s2/v1alpha1",
+    "kind": "Definition",
+    "metadata": {
+        "name": "name"
+    },
+    "job": {"kind": "Job"}
+}` + "\n"
+	if wrapped != expected {
+		t.Errorf("Wrapped doesn't match expected output\nExpected:\n%s\nAactual:\n%s", expected, wrapped)
+	}
+}

--- a/cmd/wrap/format/yaml_test.go
+++ b/cmd/wrap/format/yaml_test.go
@@ -1,0 +1,90 @@
+// Copyright 2016 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package format
+
+import (
+	"testing"
+)
+
+func TestKind(t *testing.T) {
+	f := Yaml{}
+	yaml := `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi
+spec:
+  template:
+    metadata:
+      name: pi
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never`
+	kind, err := f.ExtractKind(yaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kind != "job" {
+		t.Errorf("Extracted kind should be \"job\", is %s", kind)
+	}
+}
+
+func TestWrap(t *testing.T) {
+	f := Yaml{}
+	yaml := `  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: pi
+  spec:
+    template:
+      metadata:
+        name: pi
+      spec:
+        containers:
+        - name: pi
+          image: perl
+          command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        restartPolicy: Never`
+
+	wrapped, err := f.Wrap(yaml, "name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `apiVersion: appcontroller.k8s2/v1alpha1
+kind: Definition
+metadata:
+  name: name
+job:
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: pi
+  spec:
+    template:
+      metadata:
+        name: pi
+      spec:
+        containers:
+        - name: pi
+          image: perl
+          command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+        restartPolicy: Never`
+	if wrapped != expected {
+		t.Errorf("Wrapped doesn't match expected output\nExpected:\n%s\nAactual:\n%s", expected, wrapped)
+	}
+}

--- a/cmd/wrap/main.go
+++ b/cmd/wrap/main.go
@@ -23,12 +23,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func getInput(stream *os.File) string {
+func getInput(stream *os.File, indent int) string {
 	result := ""
+	spaces := strings.Repeat(" ", indent)
+
 	scanner := bufio.NewScanner(stream)
 	for scanner.Scan() {
-		//add two spaces of identation
-		result += "  " + scanner.Text() + "\n"
+		// add spaces for identation
+		result += spaces + scanner.Text() + "\n"
 	}
 	return result
 }
@@ -57,7 +59,7 @@ metadata:
 }
 
 func main() {
-	definition := getInput(os.Stdin)
+	definition := getInput(os.Stdin, 2)
 	out, err := getWrappedYaml(definition, os.Args[1])
 	if err != nil {
 		panic(err)

--- a/cmd/wrap/main.go
+++ b/cmd/wrap/main.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -36,11 +38,29 @@ func getInput(stream *os.File, indent int) string {
 }
 
 func main() {
-	f := format.Yaml{}
+	var fileFormat string
+	flag.StringVar(&fileFormat, "f", "yaml", "file format")
+
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) != 1 {
+		log.Fatal("Expected one positional argument: name")
+	}
+
+	var f format.Format
+	switch fileFormat {
+	case "yaml":
+		f = format.Yaml{}
+	case "json":
+		f = format.Json{}
+	default:
+		log.Fatal("Unknonwn file format. Expected one of: yaml, json")
+	}
 
 	definition := getInput(os.Stdin, f.IndentLevel())
 
-	out, err := f.Wrap(definition, os.Args[1])
+	out, err := f.Wrap(definition, args[0])
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/wrap/main_test.go
+++ b/cmd/wrap/main_test.go
@@ -22,98 +22,40 @@ import (
 )
 
 func TestInput(t *testing.T) {
-	in, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer in.Close()
-
-	content := "trololo\n lololo\n lololo\n\n"
-	expected := "  trololo\n   lololo\n   lololo\n  \n"
-
-	_, err = io.WriteString(in, content)
-	if err != nil {
-		t.Fatal(err)
+	var inputTests = []struct {
+		content  string
+		indent   int
+		expected string
+	}{
+		{"trololo\n lololo\n lololo\n\n", 1, " trololo\n  lololo\n  lololo\n \n"},
+		{"trololo\n lololo\n lololo\n\n", 2, "  trololo\n   lololo\n   lololo\n  \n"},
 	}
 
-	_, err = in.Seek(0, os.SEEK_SET)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for tc, tt := range inputTests {
+		in, err := ioutil.TempFile("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer in.Close()
 
-	result := getInput(in)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if result != expected {
-		t.Errorf("\"%s\" is not equal to \"%s\"", result, expected)
-	}
+		_, err = io.WriteString(in, tt.content)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-}
+		_, err = in.Seek(0, os.SEEK_SET)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-func TestKind(t *testing.T) {
-	yaml := `apiVersion: batch/v1
-kind: Job
-metadata:
-  name: pi
-spec:
-  template:
-    metadata:
-      name: pi
-    spec:
-      containers:
-      - name: pi
-        image: perl
-        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
-      restartPolicy: Never`
-	kind, err := getKind(yaml)
-	if err != nil {
-		t.Fatal(err)
-	}
+		result := getInput(in, tt.indent)
 
-	if kind != "job" {
-		t.Errorf("Extracted kind should be \"job\", is %s", kind)
-	}
-}
-
-func TestWrap(t *testing.T) {
-	yaml := `  apiVersion: batch/v1
-  kind: Job
-  metadata:
-    name: pi
-  spec:
-    template:
-      metadata:
-        name: pi
-      spec:
-        containers:
-        - name: pi
-          image: perl
-          command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
-        restartPolicy: Never`
-
-	wrapped, err := getWrappedYaml(yaml, "name")
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := `apiVersion: appcontroller.k8s2/v1alpha1
-kind: Definition
-metadata:
-  name: name
-job:
-  apiVersion: batch/v1
-  kind: Job
-  metadata:
-    name: pi
-  spec:
-    template:
-      metadata:
-        name: pi
-      spec:
-        containers:
-        - name: pi
-          image: perl
-          command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
-        restartPolicy: Never`
-	if wrapped != expected {
-		t.Errorf("Wrapped doesn't match expected output\nExpected:\n%s\nAactual:\n%s", expected, wrapped)
+		if result != tt.expected {
+			t.Errorf("\"%s\" is not equal to \"%s\" in test case %d", result, tt.expected, tc+1)
+		}
 	}
 }


### PR DESCRIPTION
This PR provides a small refactor in `wrap` command.
File format is extracted into separate package/interface.
Added `json` as file format.
`yaml` as default format (no changed behavior in usage).
Additional error checking on missing `name` required parameter.

Fixes #61 

TODO:
* [x] update tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/62)
<!-- Reviewable:end -->
