### PR TITLE
Wrapped resource doesn't need name from user

### DIFF
--- a/cmd/wrap/format/format.go
+++ b/cmd/wrap/format/format.go
@@ -15,11 +15,15 @@
 package format
 
 type Format interface {
-	ExtractKind(k8sObject string) (string, error)
-	Wrap(k8sObject string, name string) (string, error)
+	ExtractData(k8sObject string) (DataExtractor, error)
+	Wrap(k8sObject string) (string, error)
 	IndentLevel() int
 }
 
-type KindExtractor struct {
-	Kind string "kind"
+// DataExtractor is a type for extracting data relevant for wrap tool from serialized k8s objects
+type DataExtractor struct {
+	Kind     string "kind"
+	Metadata struct {
+		Name string "name"
+	} "metadata"
 }

--- a/cmd/wrap/format/json_test.go
+++ b/cmd/wrap/format/json_test.go
@@ -21,21 +21,21 @@ import (
 func TestKindJson(t *testing.T) {
 	f := Json{}
 	text := `{"kind": "Job"}`
-	kind, err := f.ExtractKind(text)
+	kind, err := f.ExtractData(text)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if kind != "job" {
+	if kind.Kind != "job" {
 		t.Errorf("Extracted kind should be \"job\", is %s", kind)
 	}
 }
 
 func TestWrapJson(t *testing.T) {
 	f := Json{}
-	text := `{"kind": "Job"}` + "\n"
+	text := `{"kind": "Job", "metadata": {"name": "name"}}` + "\n"
 
-	wrapped, err := f.Wrap(text, "name")
+	wrapped, err := f.Wrap(text)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,9 +43,9 @@ func TestWrapJson(t *testing.T) {
     "apiVersion": "appcontroller.k8s2/v1alpha1",
     "kind": "Definition",
     "metadata": {
-        "name": "name"
+        "name": "job-name"
     },
-    "job": {"kind": "Job"}
+    "job": {"kind": "Job", "metadata": {"name": "name"}}
 }` + "\n"
 	if wrapped != expected {
 		t.Errorf("Wrapped doesn't match expected output\nExpected:\n%s\nAactual:\n%s", expected, wrapped)

--- a/cmd/wrap/format/yaml_test.go
+++ b/cmd/wrap/format/yaml_test.go
@@ -34,12 +34,12 @@ spec:
         image: perl
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
       restartPolicy: Never`
-	kind, err := f.ExtractKind(yaml)
+	kind, err := f.ExtractData(yaml)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if kind != "job" {
+	if kind.Kind != "job" {
 		t.Errorf("Extracted kind should be \"job\", is %s", kind)
 	}
 }
@@ -61,14 +61,14 @@ func TestWrap(t *testing.T) {
           command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
         restartPolicy: Never`
 
-	wrapped, err := f.Wrap(yaml, "name")
+	wrapped, err := f.Wrap(yaml)
 	if err != nil {
 		t.Fatal(err)
 	}
 	expected := `apiVersion: appcontroller.k8s2/v1alpha1
 kind: Definition
 metadata:
-  name: name
+  name: job-pi
 job:
   apiVersion: batch/v1
   kind: Job
@@ -86,5 +86,80 @@ job:
         restartPolicy: Never`
 	if wrapped != expected {
 		t.Errorf("Wrapped doesn't match expected output\nExpected:\n%s\nAactual:\n%s", expected, wrapped)
+	}
+}
+
+// TestMultiDoc checks if multi-document yaml file is wrapped properly
+func TestMultiDoc(t *testing.T) {
+	f := Yaml{}
+	yaml := `  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: pi
+  spec:
+    trolo:
+      lolo: lo
+  ---
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: pi2
+  spec:
+    trolo:
+      lolo: lo
+  ---
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: pi3
+  spec:
+    trolo:
+      lolo: lo`
+
+	wrapped, err := f.Wrap(yaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `apiVersion: appcontroller.k8s2/v1alpha1
+kind: Definition
+metadata:
+  name: job-pi
+job:
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: pi
+  spec:
+    trolo:
+      lolo: lo
+---
+apiVersion: appcontroller.k8s2/v1alpha1
+kind: Definition
+metadata:
+  name: job-pi2
+job:
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: pi2
+  spec:
+    trolo:
+      lolo: lo
+---
+apiVersion: appcontroller.k8s2/v1alpha1
+kind: Definition
+metadata:
+  name: job-pi3
+job:
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: pi3
+  spec:
+    trolo:
+      lolo: lo`
+
+	if wrapped != expected {
+		t.Errorf("Wrapped doesn't match expected output\nExpected:\n%s\nactual:\n%s", expected, wrapped)
 	}
 }

--- a/cmd/wrap/main.go
+++ b/cmd/wrap/main.go
@@ -43,11 +43,6 @@ func main() {
 
 	flag.Parse()
 
-	args := flag.Args()
-	if len(args) != 1 {
-		log.Fatal("Expected one positional argument: name")
-	}
-
 	var f format.Format
 	switch fileFormat {
 	case "yaml":
@@ -60,7 +55,7 @@ func main() {
 
 	definition := getInput(os.Stdin, f.IndentLevel())
 
-	out, err := f.Wrap(definition, args[0])
+	out, err := f.Wrap(definition)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Yaml format supportis multi-document files ("---" delimited)

fixes #73 #75 (#73 makes sense only for yaml files, since json doesn't support multi-document files).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/76)
<!-- Reviewable:end -->
