### PR TITLE
AppController selectors are defined on pod creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,19 @@ Start appcontroller process:
 You can stop appcontroller process by:
 
 `kubectl exec k8s-appcontroller ac-stop`
+
+# Multiple AppControllers
+
+You can have multiple AppController pods running in your Kubernetes cluster. You can separate your workloads by labeling your Dependencies and Definitions.
+
+Your AppController objects will be retrieved by AppController for processing based on the selector you provide inside pod environment variable `APPCONTROLLER_LABEL_SELECTOR`. You can pass this variable to pod using Kubernetes environment variable passing mechanism (empty environment variable is already in `manifests/appcontroller.yaml` file for you to fill).
+
+## Example
+
+Example value of this variable could be `app=app1`. AppController pod with this value in `APPCONTROLLER_LABEL_SELECTOR` variable will work only with Dependencies and Definitions that contain `app: app1` key-value pair in their `metadata.labels` section.
+
+
+## Special cases
+If the selector is empty, the AppController pod will use all Dependencies and Definitions available in cluster.
+
+You can also override this behaviour by using `-l` flag for `kubeac deploy` command available on AppController pod, but this should be only done for testing purposes and is not encouraged in production.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -29,7 +29,7 @@ var RootCmd *cobra.Command
 func Init() {
 	var err error
 	var labelSelector string
-	Run.Flags().StringVarP(&labelSelector, "label", "l", "", "label selector")
+	Run.Flags().StringVarP(&labelSelector, "label", "l", "", "Label selector. Overrides APPCONTROLLER_LABEL_SELECTOR env variable in AppController pod.")
 
 	concurrencyString := os.Getenv("KUBERNETES_AC_CONCURRENCY")
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -39,6 +39,9 @@ func deploy(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if labelSelector == "" {
+		labelSelector = os.Getenv("APPCONTROLLER_LABEL_SELECTOR")
+	}
 
 	log.Println("Using concurrency:", concurrency)
 

--- a/manifests/appcontroller.yaml
+++ b/manifests/appcontroller.yaml
@@ -10,3 +10,6 @@ spec:
   - name: kubeac
     image: mirantis/k8s-appcontroller
     command:  ["/usr/bin/run_runit"]
+    env:
+    - name: APPCONTROLLER_LABEL_SELECTOR
+      value: ""


### PR DESCRIPTION
AppController pod has APPCONTROLLER_LABEL_SELECTOR env variable, which
holds the selector to be used in Dependencies and Definitions retrieval.

`labels` flag for `kubeac deploy` is retained for testing purposes.

fixes #87

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/88)
<!-- Reviewable:end -->
