### PR TITLE
Added get-status command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -29,10 +29,14 @@ func Init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	status, err := InitGetStatusCommand()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	var format string
 	Wrap.Flags().StringVarP(&format, "format", "f", "yaml", "file format")
 
 	RootCmd = &cobra.Command{Use: "ac"}
-	RootCmd.AddCommand(Bootstrap, run, Wrap)
+	RootCmd.AddCommand(Bootstrap, run, Wrap, status)
 }

--- a/cmd/get-status.go
+++ b/cmd/get-status.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/scheduler"
+	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// GetStatus is a command that prints the deployment status
+func getStatus(cmd *cobra.Command, args []string) {
+	var err error
+
+	labelSelector, err := getLabelSelector(cmd)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	shouldReport, err := cmd.Flags().GetBool("report")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var url string
+	if len(args) > 0 {
+		url = args[0]
+	}
+	if url == "" {
+		url = os.Getenv("KUBERNETES_CLUSTER_URL")
+	}
+
+	c, err := client.New(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+	sel, err := labels.Parse(labelSelector)
+	if err != nil {
+		log.Fatal(err)
+	}
+	graph, err := scheduler.BuildDependencyGraph(c, sel)
+	if err != nil {
+		log.Fatal(err)
+	}
+	status, report, _ := graph.GetStatus()
+	fmt.Printf("STATUS: %s\n", status)
+	if shouldReport {
+		fmt.Printf("REPORT:\n%s", report)
+	}
+}
+
+// InitGetStatusCommand is an initialiser for get-status
+func InitGetStatusCommand() (*cobra.Command, error) {
+	var err error
+	run := &cobra.Command{
+		Use:   "get-status",
+		Short: "Get status of deployment",
+		Long:  "Get status of deployment",
+		Run:   getStatus,
+	}
+	var labelSelector string
+	run.Flags().StringVarP(&labelSelector, "label", "l", "", "Label selector. Overrides KUBERNETES_AC_LABEL_SELECTOR env variable in AppController pod.")
+
+	var shouldReport bool
+	run.Flags().BoolVarP(&shouldReport, "report", "r", false, "Print report")
+	return run, err
+}

--- a/resources/common.go
+++ b/resources/common.go
@@ -22,6 +22,7 @@ import (
 //Resource is an interface for AppController supported resources
 type Resource interface {
 	Key() string
+	// Ensure that Status() supports nil as meta
 	Status(meta map[string]string) (string, error)
 	Create() error
 }


### PR DESCRIPTION
The 'get-status' command would print the information about the status of
deployment.
fixes #78

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/90)
<!-- Reviewable:end -->