### PR TITLE
Set envvars naming to KUBERNETES_AC_{something} pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ You can stop appcontroller process by:
 
 You can have multiple AppController pods running in your Kubernetes cluster. You can separate your workloads by labeling your Dependencies and Definitions.
 
-Your AppController objects will be retrieved by AppController for processing based on the selector you provide inside pod environment variable `APPCONTROLLER_LABEL_SELECTOR`. You can pass this variable to pod using Kubernetes environment variable passing mechanism (empty environment variable is already in `manifests/appcontroller.yaml` file for you to fill).
+Your AppController objects will be retrieved by AppController for processing based on the selector you provide inside pod environment variable `KUBERNETES_AC_LABEL_SELECTOR`. You can pass this variable to pod using Kubernetes environment variable passing mechanism (empty environment variable is already in `manifests/appcontroller.yaml` file for you to fill).
 
 ## Example
 
-Example value of this variable could be `app=app1`. AppController pod with this value in `APPCONTROLLER_LABEL_SELECTOR` variable will work only with Dependencies and Definitions that contain `app: app1` key-value pair in their `metadata.labels` section.
+Example value of this variable could be `app=app1`. AppController pod with this value in `KUBERNETES_AC_LABEL_SELECTOR` variable will work only with Dependencies and Definitions that contain `app: app1` key-value pair in their `metadata.labels` section.
 
 
 ## Special cases

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -94,7 +94,7 @@ func deploy(cmd *cobra.Command, args []string) {
 func getLabelSelector(cmd *cobra.Command) (string, error) {
 	labelSelector, err := cmd.Flags().GetString("label")
 	if labelSelector == "" {
-		labelSelector = os.Getenv("APPCONTROLLER_LABEL_SELECTOR")
+		labelSelector = os.Getenv("KUBERNETES_AC_LABEL_SELECTOR")
 	}
 	return labelSelector, err
 }
@@ -109,7 +109,7 @@ func InitRunCommand() (*cobra.Command, error) {
 	}
 
 	var labelSelector string
-	run.Flags().StringVarP(&labelSelector, "label", "l", "", "Label selector. Overrides APPCONTROLLER_LABEL_SELECTOR env variable in AppController pod.")
+	run.Flags().StringVarP(&labelSelector, "label", "l", "", "Label selector. Overrides KUBERNETES_AC_LABEL_SELECTOR env variable in AppController pod.")
 
 	concurrencyString := os.Getenv("KUBERNETES_AC_CONCURRENCY")
 

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -33,7 +33,7 @@ func TestEmptyLabel(t *testing.T) {
 func TestLabelEnv(t *testing.T) {
 	cmd, _ := InitRunCommand()
 	val := "TEST_KEY=TEST_VALUE"
-	os.Setenv("APPCONTROLLER_LABEL_SELECTOR", val)
+	os.Setenv("KUBERNETES_AC_LABEL_SELECTOR", val)
 	label, _ := getLabelSelector(cmd)
 
 	if label != val {
@@ -47,7 +47,7 @@ func TestLabelFlag(t *testing.T) {
 
 	val := "TEST_KEY=TEST_VALUE"
 	val2 := "TEST_OTHER_KEY=TEST_OTHER_VALUE"
-	os.Setenv("APPCONTROLLER_LABEL_SELECTOR", val)
+	os.Setenv("KUBERNETES_AC_LABEL_SELECTOR", val)
 	cmd.Flags().Parse([]string{"-l", val2})
 
 	label, _ := getLabelSelector(cmd)

--- a/manifests/appcontroller.yaml
+++ b/manifests/appcontroller.yaml
@@ -11,5 +11,5 @@ spec:
     image: mirantis/k8s-appcontroller
     command:  ["/usr/bin/run_runit"]
     env:
-    - name: APPCONTROLLER_LABEL_SELECTOR
+    - name: KUBERNETES_AC_LABEL_SELECTOR
       value: ""


### PR DESCRIPTION
Addresses #91

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/92)
<!-- Reviewable:end -->
