### PR TITLE
Corrected typo and changed "this" to "current"

### DIFF
--- a/docs/research/failure-handling.md
+++ b/docs/research/failure-handling.md
@@ -12,8 +12,8 @@ Kubernetes object. Possible reactions include:
  1. **Retry**: AC tries to delete failed K8s resource and then re-create it. We should be able to set maximum retries and delay before the next retry.
  2. **Rollback**: AC deletes all resourses that were created during current run.
  3. **Abort**: Immediate quit, keep all created resources.
- 4. **Ignore this**: AC proceeds with creating resources as if current one was created successfully.
- 5. **Ignore childer**: AC skips creation of all resources depending on the current one and all cascade dependencies, but proceeds with creating the rest of resources.
+ 4. **Ignore current**: AC proceeds with creating resources as if current one was created successfully.
+ 5. **Ignore children**: AC skips creation of all resources depending on the current one and all cascade dependencies, but proceeds with creating the rest of resources.
 
 Also during discussion in the community several additional features related  to the topic were requested:
 


### PR DESCRIPTION
Corrected "childer" to "children" (typo from previous PR, and changed "this" to current to better reflect the naming

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/102)
<!-- Reviewable:end -->
