### PR TITLE
Refactor for ease of adding new resource types

### DIFF
--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -1,0 +1,28 @@
+// Copyright 2016 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interfaces
+
+import "github.com/Mirantis/k8s-AppController/client"
+
+//Resource is an interface for AppController supported resources
+type Resource interface {
+	Key() string
+	// Ensure that Status() supports nil as meta
+	Status(meta map[string]string) (string, error)
+	Create() error
+	NameMatches(client.ResourceDefinition, string) bool
+	New(client.ResourceDefinition, client.Interface) Resource
+	NewExisting(string, client.Interface) Resource
+}

--- a/mocks/countingresource.go
+++ b/mocks/countingresource.go
@@ -14,7 +14,12 @@
 
 package mocks
 
-import "time"
+import (
+	"time"
+
+	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
+)
 
 //CountingResource is a fake resource that becomes ready after given timeout.
 //It also increases the counter when started and decreases it when becomes ready
@@ -47,6 +52,18 @@ func (c *CountingResource) Create() error {
 	c.counter.Inc()
 	c.startTime = time.Now()
 	return nil
+}
+
+func (c *CountingResource) NameMatches(_ client.ResourceDefinition, _ string) bool {
+	return true
+}
+
+func (c *CountingResource) New(_ client.ResourceDefinition, _ client.Interface) interfaces.Resource {
+	return NewResource("fake", "ready")
+}
+
+func (c *CountingResource) NewExisting(name string, _ client.Interface) interfaces.Resource {
+	return NewResource(name, "ready")
 }
 
 //NewCountingResource creates new instance of CountingResource

--- a/mocks/countingresource.go
+++ b/mocks/countingresource.go
@@ -54,14 +54,17 @@ func (c *CountingResource) Create() error {
 	return nil
 }
 
+// NameMatches returns true
 func (c *CountingResource) NameMatches(_ client.ResourceDefinition, _ string) bool {
 	return true
 }
 
+// New returns new fake resource
 func (c *CountingResource) New(_ client.ResourceDefinition, _ client.Interface) interfaces.Resource {
 	return NewResource("fake", "ready")
 }
 
+// NewExisting returns new existing resource
 func (c *CountingResource) NewExisting(name string, _ client.Interface) interfaces.Resource {
 	return NewResource(name, "ready")
 }

--- a/mocks/resource.go
+++ b/mocks/resource.go
@@ -14,6 +14,11 @@
 
 package mocks
 
+import (
+	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
+)
+
 //Resource is a fake resource
 type Resource struct {
 	key    string
@@ -33,6 +38,18 @@ func (c *Resource) Status(meta map[string]string) (string, error) {
 //Create does nothing
 func (c *Resource) Create() error {
 	return nil
+}
+
+func (c *Resource) NameMatches(_ client.ResourceDefinition, _ string) bool {
+	return true
+}
+
+func (c *Resource) New(_ client.ResourceDefinition, _ client.Interface) interfaces.Resource {
+	return NewResource("fake", "ready")
+}
+
+func (c *Resource) NewExisting(name string, _ client.Interface) interfaces.Resource {
+	return NewResource(name, "ready")
 }
 
 //NewResource creates new instance of Resource

--- a/mocks/resource.go
+++ b/mocks/resource.go
@@ -40,14 +40,17 @@ func (c *Resource) Create() error {
 	return nil
 }
 
+// NameMatches returns true
 func (c *Resource) NameMatches(_ client.ResourceDefinition, _ string) bool {
 	return true
 }
 
+// New returns new fake resource
 func (c *Resource) New(_ client.ResourceDefinition, _ client.Interface) interfaces.Resource {
 	return NewResource("fake", "ready")
 }
 
+// NewExisting returns new existing resource
 func (c *Resource) NewExisting(name string, _ client.Interface) interfaces.Resource {
 	return NewResource(name, "ready")
 }

--- a/resources/common.go
+++ b/resources/common.go
@@ -17,17 +17,20 @@ package resources
 import (
 	"fmt"
 	"log"
+
+	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
-//Resource is an interface for AppController supported resources
-type Resource interface {
-	Key() string
-	// Ensure that Status() supports nil as meta
-	Status(meta map[string]string) (string, error)
-	Create() error
+var KindToResource = map[string]interfaces.Resource{
+	"daemonset":  DaemonSet{},
+	"job":        Job{},
+	"petset":     PetSet{},
+	"pod":        Pod{},
+	"replicaset": ReplicaSet{},
+	"service":    Service{},
 }
 
-func resourceListReady(resources []Resource) (string, error) {
+func resourceListReady(resources []interfaces.Resource) (string, error) {
 	for _, r := range resources {
 		log.Printf("Checking status for resource %s", r.Key())
 		status, err := r.Status(nil)

--- a/resources/common.go
+++ b/resources/common.go
@@ -21,6 +21,8 @@ import (
 	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
+// KindToResource is a map mapping kind strings to empty structs representing proper resources
+// structs implement interfaces.Resource
 var KindToResource = map[string]interfaces.Resource{
 	"daemonset":  DaemonSet{},
 	"job":        Job{},
@@ -30,10 +32,11 @@ var KindToResource = map[string]interfaces.Resource{
 	"service":    Service{},
 }
 
+// Kinds is slice of keys from KindToResource
 var Kinds = getKeys(KindToResource)
 
 func getKeys(m map[string]interfaces.Resource) (keys []string) {
-	for key, _ := range m {
+	for key := range m {
 		keys = append(keys, key)
 	}
 

--- a/resources/common.go
+++ b/resources/common.go
@@ -30,6 +30,16 @@ var KindToResource = map[string]interfaces.Resource{
 	"service":    Service{},
 }
 
+var Kinds = getKeys(KindToResource)
+
+func getKeys(m map[string]interfaces.Resource) (keys []string) {
+	for key, _ := range m {
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
 func resourceListReady(resources []interfaces.Resource) (string, error) {
 	for _, r := range resources {
 		log.Printf("Checking status for resource %s", r.Key())

--- a/resources/daemonset.go
+++ b/resources/daemonset.go
@@ -6,6 +6,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
 //DaemonSet is wrapper for K8s DaemonSet object
@@ -58,6 +61,18 @@ func (d DaemonSet) Create() error {
 	return err
 }
 
+func (d DaemonSet) NameMatches(def client.ResourceDefinition, name string) bool {
+	return def.DaemonSet != nil && def.DaemonSet.Name == name
+}
+
+func (d DaemonSet) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
+	return NewDaemonSet(def.DaemonSet, c.DaemonSets())
+}
+
+func (d DaemonSet) NewExisting(name string, c client.Interface) interfaces.Resource {
+	return NewExistingDaemonSet(name, c.DaemonSets())
+}
+
 //NewDaemonSet is a constructor
 func NewDaemonSet(daemonset *extensions.DaemonSet, client unversioned.DaemonSetInterface) DaemonSet {
 	return DaemonSet{DaemonSet: daemonset, Client: client}
@@ -67,6 +82,7 @@ func NewDaemonSet(daemonset *extensions.DaemonSet, client unversioned.DaemonSetI
 type ExistingDaemonSet struct {
 	Name   string
 	Client unversioned.DaemonSetInterface
+	DaemonSet
 }
 
 //UpdateMeta does nothing at the moment

--- a/resources/daemonset.go
+++ b/resources/daemonset.go
@@ -61,14 +61,18 @@ func (d DaemonSet) Create() error {
 	return err
 }
 
+// NameMatches gets resource definition and a name and checks if
+// the DaemonSet part of resource definition has matching name.
 func (d DaemonSet) NameMatches(def client.ResourceDefinition, name string) bool {
 	return def.DaemonSet != nil && def.DaemonSet.Name == name
 }
 
+// New returns new DaemonSet based on resource definition
 func (d DaemonSet) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
 	return NewDaemonSet(def.DaemonSet, c.DaemonSets())
 }
 
+// NewExisting returns new ExistingDaemonSet based on resource definition
 func (d DaemonSet) NewExisting(name string, c client.Interface) interfaces.Resource {
 	return NewExistingDaemonSet(name, c.DaemonSets())
 }

--- a/resources/job.go
+++ b/resources/job.go
@@ -20,6 +20,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
 type Job struct {
@@ -69,6 +72,18 @@ func (s Job) Create() error {
 	return err
 }
 
+func (j Job) NameMatches(def client.ResourceDefinition, name string) bool {
+	return def.Job != nil && def.Job.Name == name
+}
+
+func (j Job) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
+	return NewJob(def.Job, c.Jobs())
+}
+
+func (j Job) NewExisting(name string, c client.Interface) interfaces.Resource {
+	return NewExistingJob(name, c.Jobs())
+}
+
 func NewJob(job *batch.Job, client unversioned.JobInterface) Job {
 	return Job{Job: job, Client: client}
 }
@@ -76,6 +91,7 @@ func NewJob(job *batch.Job, client unversioned.JobInterface) Job {
 type ExistingJob struct {
 	Name   string
 	Client unversioned.JobInterface
+	Job
 }
 
 func (s ExistingJob) Key() string {

--- a/resources/job.go
+++ b/resources/job.go
@@ -49,37 +49,44 @@ func jobStatus(j unversioned.JobInterface, name string) (string, error) {
 	return "not ready", nil
 }
 
-func (s Job) Key() string {
-	return jobKey(s.Job.Name)
+// Key returns job name
+func (j Job) Key() string {
+	return jobKey(j.Job.Name)
 }
 
-func (s Job) Status(meta map[string]string) (string, error) {
-	return jobStatus(s.Client, s.Job.Name)
+// Status returns job status
+func (j Job) Status(meta map[string]string) (string, error) {
+	return jobStatus(j.Client, j.Job.Name)
 }
 
-func (s Job) Create() error {
-	log.Println("Looking for job", s.Job.Name)
-	status, err := s.Status(nil)
+// Create creates k8s job object
+func (j Job) Create() error {
+	log.Println("Looking for job", j.Job.Name)
+	status, err := j.Status(nil)
 
 	if err == nil {
-		log.Printf("Found job %s, status:%s", s.Job.Name, status)
-		log.Println("Skipping creation of job", s.Job.Name)
+		log.Printf("Found job %s, status:%s", j.Job.Name, status)
+		log.Println("Skipping creation of job", j.Job.Name)
 		return nil
 	}
 
-	log.Println("Creating job", s.Job.Name)
-	s.Job, err = s.Client.Create(s.Job)
+	log.Println("Creating job", j.Job.Name)
+	j.Job, err = j.Client.Create(j.Job)
 	return err
 }
 
+// NameMatches gets resource definition and a name and checks if
+// the Job part of resource definition has matching name.
 func (j Job) NameMatches(def client.ResourceDefinition, name string) bool {
 	return def.Job != nil && def.Job.Name == name
 }
 
+// New returns new Job on resource definition
 func (j Job) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
 	return NewJob(def.Job, c.Jobs())
 }
 
+// NewExisting returns new ExistingJob based on resource definition
 func (j Job) NewExisting(name string, c client.Interface) interfaces.Resource {
 	return NewExistingJob(name, c.Jobs())
 }

--- a/resources/petset.go
+++ b/resources/petset.go
@@ -103,14 +103,18 @@ func (p PetSet) Status(meta map[string]string) (string, error) {
 	return petSetStatus(p.Client, p.PetSet.Name, p.APIClient)
 }
 
+// NameMatches gets resource definition and a name and checks if
+// the PetSet part of resource definition has matching name.
 func (p PetSet) NameMatches(def client.ResourceDefinition, name string) bool {
 	return def.PetSet != nil && def.PetSet.Name == name
 }
 
+// New returns new PetSet based on resource definition
 func (p PetSet) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
 	return NewPetSet(def.PetSet, c.PetSets(), c)
 }
 
+// NewExisting returns new ExistingPetSet based on resource definition
 func (p PetSet) NewExisting(name string, c client.Interface) interfaces.Resource {
 	return NewExistingPetSet(name, c.PetSets(), c)
 }

--- a/resources/petset.go
+++ b/resources/petset.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 
 	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
 // PetSet is a wrapper for K8s PetSet object
@@ -58,7 +59,7 @@ func petSetStatus(p unversioned.PetSetInterface, name string, apiClient client.I
 	if err != nil {
 		return "error", err
 	}
-	resources := make([]Resource, 0, len(pods.Items))
+	resources := make([]interfaces.Resource, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		p := pod
 		resources = append(resources, NewPod(&p, apiClient.Pods()))
@@ -102,6 +103,18 @@ func (p PetSet) Status(meta map[string]string) (string, error) {
 	return petSetStatus(p.Client, p.PetSet.Name, p.APIClient)
 }
 
+func (p PetSet) NameMatches(def client.ResourceDefinition, name string) bool {
+	return def.PetSet != nil && def.PetSet.Name == name
+}
+
+func (p PetSet) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
+	return NewPetSet(def.PetSet, c.PetSets(), c)
+}
+
+func (p PetSet) NewExisting(name string, c client.Interface) interfaces.Resource {
+	return NewExistingPetSet(name, c.PetSets(), c)
+}
+
 // NewPetSet is a constructor
 func NewPetSet(petSet *apps.PetSet, client unversioned.PetSetInterface, apiClient client.Interface) PetSet {
 	return PetSet{PetSet: petSet, Client: client, APIClient: apiClient}
@@ -112,6 +125,7 @@ type ExistingPetSet struct {
 	Name      string
 	Client    unversioned.PetSetInterface
 	APIClient client.Interface
+	PetSet
 }
 
 // Key returns PetSet name

--- a/resources/pod.go
+++ b/resources/pod.go
@@ -84,14 +84,18 @@ func (p Pod) Status(meta map[string]string) (string, error) {
 	return podStatus(p.Client, p.Pod.Name)
 }
 
+// NameMatches gets resource definition and a name and checks if
+// the Pod part of resource definition has matching name.
 func (p Pod) NameMatches(def client.ResourceDefinition, name string) bool {
 	return def.Pod != nil && def.Pod.Name == name
 }
 
+// New returns new Pod based on resource definition
 func (p Pod) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
 	return NewPod(def.Pod, c.Pods())
 }
 
+// NewExisting returns new ExistingPod based on resource definition
 func (p Pod) NewExisting(name string, c client.Interface) interfaces.Resource {
 	return NewExistingPod(name, c.Pods())
 }

--- a/resources/pod.go
+++ b/resources/pod.go
@@ -20,6 +20,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
 type Pod struct {
@@ -81,6 +84,18 @@ func (p Pod) Status(meta map[string]string) (string, error) {
 	return podStatus(p.Client, p.Pod.Name)
 }
 
+func (p Pod) NameMatches(def client.ResourceDefinition, name string) bool {
+	return def.Pod != nil && def.Pod.Name == name
+}
+
+func (p Pod) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
+	return NewPod(def.Pod, c.Pods())
+}
+
+func (p Pod) NewExisting(name string, c client.Interface) interfaces.Resource {
+	return NewExistingPod(name, c.Pods())
+}
+
 func NewPod(pod *api.Pod, client unversioned.PodInterface) Pod {
 	return Pod{Pod: pod, Client: client}
 }
@@ -88,6 +103,7 @@ func NewPod(pod *api.Pod, client unversioned.PodInterface) Pod {
 type ExistingPod struct {
 	Name   string
 	Client unversioned.PodInterface
+	Pod
 }
 
 func (p ExistingPod) Key() string {

--- a/resources/replicaset.go
+++ b/resources/replicaset.go
@@ -90,14 +90,18 @@ func (r ReplicaSet) Status(meta map[string]string) (string, error) {
 	return replicaSetStatus(r.Client, r.ReplicaSet.Name, meta)
 }
 
+// NameMatches gets resource definition and a name and checks if
+// the ReplicaSet part of resource definition has matching name.
 func (r ReplicaSet) NameMatches(def client.ResourceDefinition, name string) bool {
 	return def.ReplicaSet != nil && def.ReplicaSet.Name == name
 }
 
+// New returns new ReplicaSet based on resource definition
 func (r ReplicaSet) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
 	return NewReplicaSet(def.ReplicaSet, c.ReplicaSets())
 }
 
+// NewExisting returns new ExistingReplicaSet based on resource definition
 func (r ReplicaSet) NewExisting(name string, c client.Interface) interfaces.Resource {
 	return NewExistingReplicaSet(name, c.ReplicaSets())
 }

--- a/resources/replicaset.go
+++ b/resources/replicaset.go
@@ -21,6 +21,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
 type ReplicaSet struct {
@@ -87,6 +90,18 @@ func (r ReplicaSet) Status(meta map[string]string) (string, error) {
 	return replicaSetStatus(r.Client, r.ReplicaSet.Name, meta)
 }
 
+func (r ReplicaSet) NameMatches(def client.ResourceDefinition, name string) bool {
+	return def.ReplicaSet != nil && def.ReplicaSet.Name == name
+}
+
+func (r ReplicaSet) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
+	return NewReplicaSet(def.ReplicaSet, c.ReplicaSets())
+}
+
+func (r ReplicaSet) NewExisting(name string, c client.Interface) interfaces.Resource {
+	return NewExistingReplicaSet(name, c.ReplicaSets())
+}
+
 func NewReplicaSet(replicaSet *extensions.ReplicaSet, client unversioned.ReplicaSetInterface) ReplicaSet {
 	return ReplicaSet{ReplicaSet: replicaSet, Client: client}
 }
@@ -94,6 +109,7 @@ func NewReplicaSet(replicaSet *extensions.ReplicaSet, client unversioned.Replica
 type ExistingReplicaSet struct {
 	Name   string
 	Client unversioned.ReplicaSetInterface
+	ReplicaSet
 }
 
 func (r ExistingReplicaSet) Key() string {

--- a/resources/service.go
+++ b/resources/service.go
@@ -120,14 +120,18 @@ func (s Service) Status(meta map[string]string) (string, error) {
 	return serviceStatus(s.Client, s.Service.Name, s.APIClient)
 }
 
+// NameMatches gets resource definition and a name and checks if
+// the Service part of resource definition has matching name.
 func (s Service) NameMatches(def client.ResourceDefinition, name string) bool {
 	return def.Service != nil && def.Service.Name == name
 }
 
+// New returns new Service based on resource definition
 func (s Service) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
 	return NewService(def.Service, c.Services(), c)
 }
 
+// NewExisting returns new ExistingService based on resource definition
 func (s Service) NewExisting(name string, c client.Interface) interfaces.Resource {
 	return NewExistingService(name, c.Services())
 }

--- a/resources/service.go
+++ b/resources/service.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 
 	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
 type Service struct {
@@ -66,7 +67,7 @@ func serviceStatus(s unversioned.ServiceInterface, name string, apiClient client
 		if err != nil {
 			return "error", err
 		}
-		resources := make([]Resource, 0, len(pods.Items)+len(jobs.Items)+len(replicasets.Items))
+		resources := make([]interfaces.Resource, 0, len(pods.Items)+len(jobs.Items)+len(replicasets.Items))
 		for _, pod := range pods.Items {
 			p := pod
 			resources = append(resources, NewPod(&p, apiClient.Pods()))
@@ -119,6 +120,18 @@ func (s Service) Status(meta map[string]string) (string, error) {
 	return serviceStatus(s.Client, s.Service.Name, s.APIClient)
 }
 
+func (s Service) NameMatches(def client.ResourceDefinition, name string) bool {
+	return def.Service != nil && def.Service.Name == name
+}
+
+func (s Service) New(def client.ResourceDefinition, c client.Interface) interfaces.Resource {
+	return NewService(def.Service, c.Services(), c)
+}
+
+func (s Service) NewExisting(name string, c client.Interface) interfaces.Resource {
+	return NewExistingService(name, c.Services())
+}
+
 //NewService is Service constructor. Needs apiClient for service status checks
 func NewService(service *api.Service, client unversioned.ServiceInterface, apiClient client.Interface) Service {
 	return Service{Service: service, Client: client, APIClient: apiClient}
@@ -128,6 +141,7 @@ type ExistingService struct {
 	Name      string
 	Client    unversioned.ServiceInterface
 	APIClient client.Interface
+	Service
 }
 
 func (s ExistingService) Key() string {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -144,7 +144,7 @@ func NewScheduledResource(kind string, name string,
 	resource_template, ok := resources.KindToResource[kind]
 	if !ok {
 		//TODO: get kinds from KindToResourceKeys
-		return nil, fmt.Errorf("Not a proper resource kind: %s. Expected 'pod', 'job', 'service', 'replicaset' or 'daemonset'", kind)
+		return nil, fmt.Errorf("Not a proper resource kind: %s. Expected '%s'", kind, strings.Join(resources.Kinds, "', '"))
 	}
 	r = newResource(name, resDefs, c, resource_template)
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -22,10 +22,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Mirantis/k8s-AppController/client"
-	"github.com/Mirantis/k8s-AppController/resources"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/labels"
+
+	"github.com/Mirantis/k8s-AppController/client"
+	"github.com/Mirantis/k8s-AppController/interfaces"
+	"github.com/Mirantis/k8s-AppController/resources"
 )
 
 // ScheduledResourceStatus describes possible status of a single resource
@@ -76,7 +78,7 @@ type ScheduledResource struct {
 	Requires   []*ScheduledResource
 	RequiredBy []*ScheduledResource
 	Status     ScheduledResourceStatus
-	resources.Resource
+	interfaces.Resource
 	// parentKey -> dependencyMetadata
 	Meta map[string]map[string]string
 	sync.RWMutex
@@ -120,105 +122,37 @@ func (d *ScheduledResource) IsBlocked() bool {
 // ScheduledResource pointers
 type DependencyGraph map[string]*ScheduledResource
 
-func newResourceForPod(name string, resDefs []client.ResourceDefinition, c client.Interface) resources.Resource {
+func newResource(name string, resDefs []client.ResourceDefinition, c client.Interface, resource_template interfaces.Resource) interfaces.Resource {
 	for _, rd := range resDefs {
-		if rd.Pod != nil && rd.Pod.Name == name {
-			log.Println("Found resource definition for pod", name)
-			return resources.NewPod(rd.Pod, c.Pods())
+		if resource_template.NameMatches(rd, name) {
+			log.Println("Found resource definition for ", name)
+			return resource_template.New(rd, c)
 		}
 	}
 
-	log.Printf("Resource definition for pod '%s' not found, so it is expected to exist already", name)
-	return resources.NewExistingPod(name, c.Pods())
-}
+	log.Printf("Resource definition for '%s' not found, so it is expected to exist already", name)
+	return resource_template.NewExisting(name, c)
 
-func newResourceForJob(name string, resDefs []client.ResourceDefinition, c client.Interface) resources.Resource {
-	for _, rd := range resDefs {
-		if rd.Job != nil && rd.Job.Name == name {
-			log.Println("Found resource definition for job", name)
-			return resources.NewJob(rd.Job, c.Jobs())
-		}
-	}
-
-	log.Printf("Resource definition for job '%s' not found, so it is expected to exist already", name)
-	return resources.NewExistingJob(name, c.Jobs())
-}
-
-func newResourceForService(name string, resDefs []client.ResourceDefinition, c client.Interface) resources.Resource {
-	for _, rd := range resDefs {
-		if rd.Service != nil && rd.Service.Name == name {
-			log.Println("Found resource definition for service", name)
-			return resources.NewService(rd.Service, c.Services(), c)
-		}
-	}
-
-	log.Printf("Resource definition for service '%s' not found, so it is expected to exist already", name)
-	return resources.NewExistingService(name, c.Services())
-}
-
-func newResourceForReplicaSet(name string, resDefs []client.ResourceDefinition, c client.Interface) resources.Resource {
-	for _, rd := range resDefs {
-		if rd.ReplicaSet != nil && rd.ReplicaSet.Name == name {
-			log.Println("Found resource definition for replica set", name)
-			return resources.NewReplicaSet(rd.ReplicaSet, c.ReplicaSets())
-		}
-	}
-
-	log.Printf("Resource definition for replica set '%s' not found, so it is expected to exist already", name)
-	return resources.NewExistingReplicaSet(name, c.ReplicaSets())
-}
-
-func newResourceForPetSet(name string, resDefs []client.ResourceDefinition, c client.Interface) resources.Resource {
-	for _, rd := range resDefs {
-		if rd.PetSet != nil && rd.PetSet.Name == name {
-			log.Println("Found resource definition for pet set", name)
-			return resources.NewPetSet(rd.PetSet, c.PetSets(), c)
-		}
-	}
-
-	log.Printf("Resource definition for pet set '%s' not found, so it is expected to exist already", name)
-	return resources.NewExistingPetSet(name, c.PetSets(), c)
-}
-
-func newResourceForDaemonSet(name string, resDefs []client.ResourceDefinition, c client.Interface) resources.Resource {
-	for _, rd := range resDefs {
-		if rd.DaemonSet != nil && rd.DaemonSet.Name == name {
-			log.Println("Found resource definition for daemon set", name)
-			return resources.NewDaemonSet(rd.DaemonSet, c.DaemonSets())
-		}
-	}
-
-	log.Printf("Resource definition for daemon set '%s' not found, so it is expected to exist already", name)
-	return resources.NewExistingDaemonSet(name, c.DaemonSets())
 }
 
 // NewScheduledResource is a constructor for ScheduledResource
 func NewScheduledResource(kind string, name string,
 	resDefs []client.ResourceDefinition, c client.Interface) (*ScheduledResource, error) {
 
-	var r resources.Resource
+	var r interfaces.Resource
 
-	if kind == "pod" {
-		r = newResourceForPod(name, resDefs, c)
-	} else if kind == "job" {
-		r = newResourceForJob(name, resDefs, c)
-	} else if kind == "service" {
-		r = newResourceForService(name, resDefs, c)
-	} else if kind == "replicaset" {
-		r = newResourceForReplicaSet(name, resDefs, c)
-	} else if kind == "petset" {
-		r = newResourceForPetSet(name, resDefs, c)
-	} else if kind == "daemonset" {
-		r = newResourceForDaemonSet(name, resDefs, c)
-	} else {
+	resource_template, ok := resources.KindToResource[kind]
+	if !ok {
+		//TODO: get kinds from KindToResourceKeys
 		return nil, fmt.Errorf("Not a proper resource kind: %s. Expected 'pod', 'job', 'service', 'replicaset' or 'daemonset'", kind)
 	}
+	r = newResource(name, resDefs, c, resource_template)
 
 	return NewScheduledResourceFor(r), nil
 }
 
 //NewScheduledResourceFor returns new scheduled resource for given resource in init state
-func NewScheduledResourceFor(r resources.Resource) *ScheduledResource {
+func NewScheduledResourceFor(r interfaces.Resource) *ScheduledResource {
 	return &ScheduledResource{
 		Status:   Init,
 		Resource: r,

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -122,16 +122,16 @@ func (d *ScheduledResource) IsBlocked() bool {
 // ScheduledResource pointers
 type DependencyGraph map[string]*ScheduledResource
 
-func newResource(name string, resDefs []client.ResourceDefinition, c client.Interface, resource_template interfaces.Resource) interfaces.Resource {
+func newResource(name string, resDefs []client.ResourceDefinition, c client.Interface, resourceTemplate interfaces.Resource) interfaces.Resource {
 	for _, rd := range resDefs {
-		if resource_template.NameMatches(rd, name) {
+		if resourceTemplate.NameMatches(rd, name) {
 			log.Println("Found resource definition for ", name)
-			return resource_template.New(rd, c)
+			return resourceTemplate.New(rd, c)
 		}
 	}
 
 	log.Printf("Resource definition for '%s' not found, so it is expected to exist already", name)
-	return resource_template.NewExisting(name, c)
+	return resourceTemplate.NewExisting(name, c)
 
 }
 
@@ -141,12 +141,11 @@ func NewScheduledResource(kind string, name string,
 
 	var r interfaces.Resource
 
-	resource_template, ok := resources.KindToResource[kind]
+	resourceTemplate, ok := resources.KindToResource[kind]
 	if !ok {
-		//TODO: get kinds from KindToResourceKeys
 		return nil, fmt.Errorf("Not a proper resource kind: %s. Expected '%s'", kind, strings.Join(resources.Kinds, "', '"))
 	}
-	r = newResource(name, resDefs, c, resource_template)
+	r = newResource(name, resDefs, c, resourceTemplate)
 
 	return NewScheduledResourceFor(r), nil
 }


### PR DESCRIPTION
- got rid of newResourceFor* functions in scheduler
- got rid of switching by `kind` in scheduler
- extracted Resource interface to new package `interfaces` (this is
because tests are in a package they are testing, which resulted in
circular imports between `resources` and `mocks` packages)
- expanded Resource interface with methods for matching the name of
resource definition and creating new objects

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/104)
<!-- Reviewable:end -->
