### PR TITLE
Extract Resource creation methods into separate interface

### DIFF
--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -23,6 +23,10 @@ type Resource interface {
 	Status(meta map[string]string) (string, error)
 	Create() error
 	Delete() error
+}
+
+//ResourceTemplate is an interface for AppController supported resource templates
+type ResourceTemplate interface {
 	NameMatches(client.ResourceDefinition, string) bool
 	New(client.ResourceDefinition, client.Interface) Resource
 	NewExisting(string, client.Interface) Resource

--- a/resources/common.go
+++ b/resources/common.go
@@ -21,9 +21,9 @@ import (
 	"github.com/Mirantis/k8s-AppController/interfaces"
 )
 
-// KindToResource is a map mapping kind strings to empty structs representing proper resources
-// structs implement interfaces.Resource
-var KindToResource = map[string]interfaces.Resource{
+// KindToResourceTemplate is a map mapping kind strings to empty structs representing proper resources
+// structs implement interfaces.ResourceTemplate
+var KindToResourceTemplate = map[string]interfaces.ResourceTemplate{
 	"daemonset":  DaemonSet{},
 	"job":        Job{},
 	"petset":     PetSet{},
@@ -32,10 +32,10 @@ var KindToResource = map[string]interfaces.Resource{
 	"service":    Service{},
 }
 
-// Kinds is slice of keys from KindToResource
-var Kinds = getKeys(KindToResource)
+// Kinds is slice of keys from KindToResourceTemplate
+var Kinds = getKeys(KindToResourceTemplate)
 
-func getKeys(m map[string]interfaces.Resource) (keys []string) {
+func getKeys(m map[string]interfaces.ResourceTemplate) (keys []string) {
 	for key := range m {
 		keys = append(keys, key)
 	}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -122,7 +122,7 @@ func (d *ScheduledResource) IsBlocked() bool {
 // ScheduledResource pointers
 type DependencyGraph map[string]*ScheduledResource
 
-func newResource(name string, resDefs []client.ResourceDefinition, c client.Interface, resourceTemplate interfaces.Resource) interfaces.Resource {
+func newResource(name string, resDefs []client.ResourceDefinition, c client.Interface, resourceTemplate interfaces.ResourceTemplate) interfaces.Resource {
 	for _, rd := range resDefs {
 		if resourceTemplate.NameMatches(rd, name) {
 			log.Println("Found resource definition for ", name)
@@ -141,7 +141,7 @@ func NewScheduledResource(kind string, name string,
 
 	var r interfaces.Resource
 
-	resourceTemplate, ok := resources.KindToResource[kind]
+	resourceTemplate, ok := resources.KindToResourceTemplate[kind]
 	if !ok {
 		return nil, fmt.Errorf("Not a proper resource kind: %s. Expected '%s'", kind, strings.Join(resources.Kinds, "', '"))
 	}


### PR DESCRIPTION
No new functionality. Just some design beautification. Like 'I' in 'SOLID

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/111)
<!-- Reviewable:end -->
