### PR TITLE
All clients are set to use AC pod namespace

### DIFF
--- a/manifests/appcontroller.yaml
+++ b/manifests/appcontroller.yaml
@@ -13,3 +13,7 @@ spec:
     env:
     - name: KUBERNETES_AC_LABEL_SELECTOR
       value: ""
+    - name: KUBERNETES_AC_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace


### PR DESCRIPTION
fixes #95 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/112)
<!-- Reviewable:end -->
