### PR TITLE
Pin k8s to 1.4.6

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -6,6 +6,8 @@ imports:
   subpackages:
   - compute/metadata
   - internal
+- name: k8s.io/client-go
+  version: 3a5b96cfd3d3ff1d53d979b4297c4f3b869aab09
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/coreos/go-oidc

--- a/glide.lock
+++ b/glide.lock
@@ -208,7 +208,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 - name: k8s.io/kubernetes
-  version: 33103e576e5c1530fb7503a8cb854848b9da2b30
+  version: e569a27d02001e343cb68086bc06d47804f62af6
   subpackages:
   - pkg/api
   - pkg/api/errors


### PR DESCRIPTION
Pinned temporary k8s to 1.4.6 (instead of 1.5.0 alpha-something)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/119)
<!-- Reviewable:end -->
