### PR TITLE
Fix 'test' target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ vendor: Makefile
 	glide install --strip-vendor
 
 test: vendor glide.lock Makefile
-	go list ./... | grep -v /vendor/ | xargs go test
+	go list ./... | egrep -v ^vendor/ | xargs go test


### PR DESCRIPTION
Fix regexp excluding tests in vendored packages

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/121)
<!-- Reviewable:end -->
