### PR TITLE
Detect name of kubectl (kubectl vs kubectl.sh)

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -1,0 +1,8 @@
+if ! [ -z $KUBECTL_NAME ]; then
+    if [ -x "$(command -v kubectl)" ]; then
+        KUBECTL_NAME='kubectl'
+    else
+        KUBECTL_NAME='$KUBECTL_NAME'
+    fi
+    export KUBECTL_NAME
+fi

--- a/examples/extended/create.sh
+++ b/examples/extended/create.sh
@@ -1,41 +1,42 @@
 #!/bin/bash
 
+source ../common.sh
 
-kubectl.sh create -f existing_job.yaml
+$KUBECTL_NAME create -f existing_job.yaml
 
-kubectl.sh create -f ../../manifests/appcontroller.yaml
+$KUBECTL_NAME create -f ../../manifests/appcontroller.yaml
 
 #wait for appcontroller pod creation
 sleep 20
 
-kubectl.sh create -f deps.yaml
+$KUBECTL_NAME create -f deps.yaml
 
-cat job.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat job2.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat job3.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat job4.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat job.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat job2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat job3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat job4.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat pod.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod2.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod3.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod4.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod5.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod6.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod7.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod8.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod9.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat pod.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod4.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod5.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod6.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod7.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod8.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod9.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat replicaset.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat replicaset.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat service.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat service.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat petset.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat petset.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat daemonset.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat daemonset.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat configmap1.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat configmap1.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat secret.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat secret.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-kubectl.sh exec k8s-appcontroller ac-run
-kubectl.sh logs -f k8s-appcontroller
+$KUBECTL_NAME exec k8s-appcontroller ac-run
+$KUBECTL_NAME logs -f k8s-appcontroller

--- a/examples/extended/delete.sh
+++ b/examples/extended/delete.sh
@@ -1,29 +1,30 @@
 #!/bin/bash
 
+source ../common.sh
 
-kubectl.sh delete -f existing_job.yaml
+$KUBECTL_NAME delete -f existing_job.yaml
 
-kubectl.sh delete -f deps.yaml
+$KUBECTL_NAME delete -f deps.yaml
 
-cat job.yaml | kubectl.sh exec -i k8s-appcontroller wrap job1 | kubectl.sh delete -f -
-cat job2.yaml | kubectl.sh exec -i k8s-appcontroller wrap job2 | kubectl.sh delete -f -
-cat job3.yaml | kubectl.sh exec -i k8s-appcontroller wrap job3 | kubectl.sh delete -f -
-cat job4.yaml | kubectl.sh exec -i k8s-appcontroller wrap job4 | kubectl.sh delete -f -
+cat job.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap job1 | $KUBECTL_NAME delete -f -
+cat job2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap job2 | $KUBECTL_NAME delete -f -
+cat job3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap job3 | $KUBECTL_NAME delete -f -
+cat job4.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap job4 | $KUBECTL_NAME delete -f -
 
-cat pod.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod1 | kubectl.sh delete -f -
-cat pod2.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod2 | kubectl.sh delete -f -
-cat pod3.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod3 | kubectl.sh delete -f -
-cat pod4.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod4 | kubectl.sh delete -f -
-cat pod5.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod5 | kubectl.sh delete -f -
-cat pod6.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod6 | kubectl.sh delete -f -
-cat pod7.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod7 | kubectl.sh delete -f -
-cat pod8.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod8 | kubectl.sh delete -f -
-cat pod9.yaml | kubectl.sh exec -i k8s-appcontroller wrap pod9 | kubectl.sh delete -f -
+cat pod.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod1 | $KUBECTL_NAME delete -f -
+cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod2 | $KUBECTL_NAME delete -f -
+cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod3 | $KUBECTL_NAME delete -f -
+cat pod4.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod4 | $KUBECTL_NAME delete -f -
+cat pod5.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod5 | $KUBECTL_NAME delete -f -
+cat pod6.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod6 | $KUBECTL_NAME delete -f -
+cat pod7.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod7 | $KUBECTL_NAME delete -f -
+cat pod8.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod8 | $KUBECTL_NAME delete -f -
+cat pod9.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap pod9 | $KUBECTL_NAME delete -f -
 
-cat replicaset.yaml | kubectl.sh exec -i k8s-appcontroller wrap frontend | kubectl.sh delete -f -
+cat replicaset.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap frontend | $KUBECTL_NAME delete -f -
 
-cat daemonset.yaml | kubectl.sh exec -i k8s-appcontroller wrap daemonset | kubectl.sh delete -f -
+cat daemonset.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap daemonset | $KUBECTL_NAME delete -f -
 
-cat secret.yaml | kubectl.sh exec -i k8s-appcontroller wrap daemonset | kubectl.sh delete -f -
+cat secret.yaml | $KUBECTL_NAME exec -i k8s-appcontroller wrap daemonset | $KUBECTL_NAME delete -f -
 
-kubectl.sh delete -f ../../manifests/appcontroller.yaml
+$KUBECTL_NAME delete -f ../../manifests/appcontroller.yaml

--- a/examples/services/create.sh
+++ b/examples/services/create.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
+
+source ../common.sh
+
 set -x
 
-kubectl.sh create -f ../../manifests/appcontroller.yaml
+$KUBECTL_NAME create -f ../../manifests/appcontroller.yaml
 
 sleep 15
 
-kubectl.sh create -f deps.yaml
+$KUBECTL_NAME create -f deps.yaml
 
-cat job.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat job.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat service.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod2.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod3.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-cat pod4.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+cat service.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod4.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-kubectl.sh exec k8s-appcontroller ac-run
+$KUBECTL_NAME exec k8s-appcontroller ac-run
 
-kubectl.sh logs -f k8s-appcontroller
+$KUBECTL_NAME logs -f k8s-appcontroller

--- a/examples/simple/create.sh
+++ b/examples/simple/create.sh
@@ -1,35 +1,36 @@
 #!/bin/bash
 
+source ../common.sh
 
 echo "Let's create the job that existed before (not being created by AppController)"
 
-echo "kubectl.sh create -f existing_job.yaml"
-kubectl.sh create -f existing_job.yaml
+echo "$KUBECTL_NAME create -f existing_job.yaml"
+$KUBECTL_NAME create -f existing_job.yaml
 
 echo "Creating pod with AppController binary. This is going to be our entry point."
-echo "kubectl.sh create -f ../../appcontroller.yaml"
-kubectl.sh create -f ../../manifests/appcontroller.yaml
+echo "$KUBECTL_NAME create -f ../../appcontroller.yaml"
+$KUBECTL_NAME create -f ../../manifests/appcontroller.yaml
 
 echo "Wait for cluster to register new endpoints and run appcontroller container"
 sleep 10
 
 echo "Let's create dependencies. Please refer to https://github.com/Mirantis/k8s-AppController/tree/demo/examples/simple/graph.svg to see the graph composition."
-echo "kubectl.sh create -f deps.yaml"
-kubectl.sh create -f deps.yaml
+echo "$KUBECTL_NAME create -f deps.yaml"
+$KUBECTL_NAME create -f deps.yaml
 
 echo "Let's create resource definitions. We are wrapping existing job and pod definitions in ResourceDefinitions. We are not creating the pods and jobs themselves - yet!"
-echo "cat job.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap job1 | kubectl.sh create -f -"
-cat job.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-echo "cat job2.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap job2 | kubectl.sh create -f -"
-cat job2.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+echo "cat job.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap job1 | $KUBECTL_NAME create -f -"
+cat job.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+echo "cat job2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap job2 | $KUBECTL_NAME create -f -"
+cat job2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-echo "cat pod.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap pod1 | kubectl.sh create -f -"
-cat pod.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-echo "cat pod2.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap pod2 | kubectl.sh create -f -"
-cat pod2.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
-echo "cat pod3.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap pod3 | kubectl.sh create -f -"
-cat pod3.yaml | kubectl.sh exec -i k8s-appcontroller kubeac wrap | kubectl.sh create -f -
+echo "cat pod.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap pod1 | $KUBECTL_NAME create -f -"
+cat pod.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+echo "cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap pod2 | $KUBECTL_NAME create -f -"
+cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+echo "cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap pod3 | $KUBECTL_NAME create -f -"
+cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
 echo "Here we are running appcontroller binary itself. As the log will say, it retrieves dependencies and resource definitions from the k8s cluster and creates underlying objects accordingly."
-echo "kubectl.sh exec k8s-appcontroller ac-run"
-kubectl.sh exec k8s-appcontroller ac-run
+echo "$KUBECTL_NAME exec k8s-appcontroller ac-run"
+$KUBECTL_NAME exec k8s-appcontroller ac-run


### PR DESCRIPTION
You can override it by manually exporting `KUBECTL_NAME`. The problem is simple, sometimes you need kubectl.sh sometimes you want kubectl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/124)
<!-- Reviewable:end -->
