### PR TITLE
Use Dockerfile from v0.2 tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN glide install --strip-vendor &&\
     glide cache-clear &&\
     rm -fr /usr/local/go /go
 
-RUN mkdir -p /etc/sv/ac
-ADD ac_service.sh /etc/sv/ac/run
-ADD run_runit.sh /usr/bin/run_runit
-ADD ac-run.sh /usr/bin/ac-run
-ADD ac-stop.sh /usr/bin/ac-stop
-RUN touch /etc/sv/ac/down
+    RUN mkdir -p /etc/sv/ac
+    ADD ac_service.sh /etc/sv/ac/run
+    ADD run_runit.sh /usr/bin/run_runit
+    ADD ac-run.sh /usr/bin/ac-run
+    ADD ac-stop.sh /usr/bin/ac-stop
+    RUN touch /etc/sv/ac/down


### PR DESCRIPTION
The current Dockerfile fails to find kubeac binary.

The version of Dockerfile from tag 0.2 seems to be fixing the problem and the appcontroller container builds succesfully

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/130)
<!-- Reviewable:end -->
