### PR TITLE
Fix extended example

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -3,5 +3,8 @@ if [ -z "$KUBECTL_NAME" ]; then
     if [ -x "$(command -v kubectl)" ]; then
         KUBECTL_NAME='kubectl'
     fi
+    if [ -x "$(command -v kubectl.sh)" ]; then
+        KUBECTL_NAME='kubectl.sh'
+    fi
 fi
 echo "Using following kubectl - ${KUBECTL_NAME}"

--- a/examples/extended/create.sh
+++ b/examples/extended/create.sh
@@ -40,7 +40,5 @@ cat secret.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL
 
 cat deployment.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-cat pvc.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
-
 $KUBECTL_NAME exec k8s-appcontroller ac-run
 $KUBECTL_NAME logs -f k8s-appcontroller

--- a/examples/extended/deps.yaml
+++ b/examples/extended/deps.yaml
@@ -193,10 +193,3 @@ metadata:
   name: 35185dfb-ca82-015b-81e5-297ba2c1235
 parent: deployment/nginx-deployment
 child: pod/eventually-alive-pod3
----
-apiVersion: appcontroller.k8s/v1alpha1
-kind: Dependency
-metadata:
-  name: 35235dfb-ca82-015b-81e5-297ba2c1235
-parent: deployment/nginx-deployment
-child: persistentvolumeclaim/myclaim


### PR DESCRIPTION
Removed PersistentVolumeClaim from example due to it not being able to
become ready on clusters without provisioned PersistentVolume

Added kubectl.sh as possible kubectl name in common.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/162)
<!-- Reviewable:end -->
