### PR TITLE
Fix service status checking for statefulsets

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -376,7 +376,9 @@ func Create(depGraph DependencyGraph, concurrency int) {
 
 	log.Printf("Wait for %d deps to create\n", depCount)
 	for i := 0; i < depCount; i++ {
-		<-created
+		log.Printf("waiting for creation of %d", i)
+		createdKey := <-created
+		log.Printf("Created %s, index: %d, waiting for %d more", createdKey, i, depCount-i-1)
 	}
 	close(toCreate)
 	close(created)


### PR DESCRIPTION
It seemed like StatefulSets were the main reason for service checking to break.

StatefulSets are specially handled now, similar code will need to be written for PetSets when their support comes back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/167)
<!-- Reviewable:end -->
