### PR TITLE
Improve import.sh script

### DIFF
--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -5,28 +5,27 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-CURDIR=$(dirname "${BASH_SOURCE}")
-
-
 IMAGE_REPO=${IMAGE_REPO:-mirantis/k8s-appcontroller}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 NUM_NODES=${NUM_NODES:-2}
-TMP_IMAGE_PATH=${TMP_IMAGE_PATH:-/tmp/appcontroller.tar}
+TMP_IMAGE_PATH=${TMP_IMAGE_PATH:-/tmp/image.tar}
+MASTER_NAME=${MASTER_NAME:-"kube-master"}
+SLAVE_PATTERN=${SLAVE_PATTERN:-"kube-node-"}
+
 
 function import-image {
-        echo "Export docker image and import it on a dind node dind_node_1"
-        CONTAINERID="$(docker create ${IMAGE_REPO}:${IMAGE_TAG} bash)"
-        set -o xtrace
-        docker export "${CONTAINERID}" > "${TMP_IMAGE_PATH}"
-        # TODO implement it as a provider (e.g source functions)
+    docker save ${IMAGE_REPO}:${IMAGE_TAG} -o "${TMP_IMAGE_PATH}"
 
-        for i in `seq 1 "${NUM_NODES}"`;
-        do
-            docker cp "${TMP_IMAGE_PATH}" dind_node_$i:/tmp
-            docker exec -ti dind_node_$i docker import "${TMP_IMAGE_PATH}" ${IMAGE_REPO}:${IMAGE_TAG}
-        done
-        set +o xtrace
-        echo "Finished copying docker image to dind nodes"
+    docker cp "${TMP_IMAGE_PATH}" kube-master:/image.tar
+    docker exec -ti "${MASTER_NAME}" docker load -i /image.tar
+
+    for i in `seq 1 "${NUM_NODES}"`;
+    do
+        docker cp "${TMP_IMAGE_PATH}" "${SLAVE_PATTERN}$i":/image.tar
+        docker exec -ti "${SLAVE_PATTERN}$i" docker load -i /image.tar
+    done
+    set +o xtrace
+    echo "Finished copying docker image to dind nodes"
 }
 
 import-image


### PR DESCRIPTION
uses save/load combo instead import/export, also changed default names to match kubeadm-dind-cluster (possible to change using ENV variables).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/175)
<!-- Reviewable:end -->
