### PR TITLE
Fix shadowing in client.IsEnabled

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -175,8 +175,9 @@ func (c Client) IsEnabled(version unversioned.GroupVersion) bool {
 		if group.Name != version.Group {
 			continue
 		}
-		for _, version := range group.Versions {
-			if version.Version == version.Version {
+		for _, v := range group.Versions {
+			if v.Version == version.Version {
+				log.Printf("Found version %v and group %v", group.Name, v.Version)
 				return true
 			}
 		}

--- a/pkg/mocks/client.go
+++ b/pkg/mocks/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mirantis/k8s-AppController/pkg/client"
 	alphafake "github.com/Mirantis/k8s-AppController/pkg/client/petsets/typed/apps/v1alpha1/fake"
 
+	"github.com/Mirantis/k8s-AppController/pkg/client/petsets/apis/apps/v1alpha1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
@@ -41,7 +42,8 @@ func makeVersionsList(version unversioned.GroupVersion) *unversioned.APIGroupLis
 		{
 			Name: version.Group,
 			Versions: []unversioned.GroupVersionForDiscovery{
-				{GroupVersion: version.Version},
+				{
+					Version: version.Version},
 			},
 		},
 	}}
@@ -50,5 +52,11 @@ func makeVersionsList(version unversioned.GroupVersion) *unversioned.APIGroupLis
 func NewClient(objects ...runtime.Object) *client.Client {
 	c := newClient(objects...)
 	c.APIVersions = makeVersionsList(v1beta1.SchemeGroupVersion)
+	return c
+}
+
+func NewClient1_4(objects ...runtime.Object) *client.Client {
+	c := newClient(objects...)
+	c.APIVersions = makeVersionsList(v1alpha1.SchemeGroupVersion)
 	return c
 }

--- a/pkg/resources/statefulset_test.go
+++ b/pkg/resources/statefulset_test.go
@@ -60,3 +60,10 @@ func TestStatefulSetIsEnabled(t *testing.T) {
 		t.Errorf("%v expected to be enabled", v1beta1.SchemeGroupVersion)
 	}
 }
+
+func TestStatefulSetDisabledOn14Version(t *testing.T) {
+	c := mocks.NewClient1_4()
+	if c.IsEnabled(v1beta1.SchemeGroupVersion) {
+		t.Errorf("%v expected to be disabled", v1beta1.SchemeGroupVersion)
+	}
+}


### PR DESCRIPTION
Fixed shadowing that were preventing client from correctly reporting
what API version is enabled/disabled.
Added unit test to verify disabled state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/187)
<!-- Reviewable:end -->
