### PR TITLE
Do not fail on clean when no .k8s-cluster found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ clean:
 .PHONY: clean-k8s
 clean-k8s:
 	<$(K8S_SOURCE_LOCATION) xargs rm -rf
-	rm $(K8S_SOURCE_LOCATION)
-	rm $(K8S_CLUSTER_MARKER)
+	-rm $(K8S_SOURCE_LOCATION)
+	-rm $(K8S_CLUSTER_MARKER)
 
 $(K8S_SOURCE_LOCATION):
 	WORKING=$(WORKING) scripts/checkout_k8s.sh > $(K8S_SOURCE_LOCATION)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/191)
<!-- Reviewable:end -->
