### PR TITLE
Publish to docker after succesfull build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ go:
   - 1.6
   - 1.7
 env:
-  - WORKING=$HOME/kube1.5 K8S_TAG=v1.5.2
+  - WORKING=$HOME/kube1.5 K8S_TAG=v1.5.2 PUBLISH=1
   - WORKING=$HOME/kube1.4 K8S_TAG=v1.4.8
 matrix:
   exclude:
     - go: 1.6
-      env: WORKING=$HOME/kube1.5 K8S_TAG=v1.5.2
+      env: WORKING=$HOME/kube1.5 K8S_TAG=v1.5.2 PUBLISH=1
     - go: 1.7
       env: WORKING=$HOME/kube1.4 K8S_TAG=v1.4.8
 cache:
@@ -22,3 +22,5 @@ script:
   - go get github.com/Masterminds/glide
   - make test
   - make e2e
+after_success:
+  - make docker-publish

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 
-TAG ?= mirantis/k8s-appcontroller
+IMAGE_REPO ?= mirantis/k8s-appcontroller
 WORKING ?= ~/testappcontroller
 K8S_SOURCE_LOCATION = .k8s-source
 K8S_CLUSTER_MARKER = .k8s-cluster
 
 .PHONY: docker
 docker: kubeac Makefile
-	docker build -t $(TAG) .
+	docker build -t $(IMAGE_REPO) .
 
 vendor: Makefile
 	glide install --strip-vendor
@@ -18,9 +18,12 @@ test: vendor glide.lock Makefile
 kubeac:
 	bash hooks/pre_build
 
+docker-publish:
+	IMAGE_REPO=$(IMAGE_REPO) ./scripts/docker_publish.sh
+
 .PHONY: img-in-dind
 img-in-dind: docker $(K8S_CLUSTER_MARKER)
-	IMAGE_REPO=mirantis/k8s-appcontroller bash scripts/import.sh
+	IMAGE_REPO=$(IMAGE_REPO) bash scripts/import.sh
 
 .PHONY: e2e
 e2e: $(K8S_CLUSTER_MARKER) img-in-dind
@@ -33,7 +36,7 @@ clean-all: clean clean-k8s
 .PHONY: clean
 clean:
 	rm -f kubeac
-	-docker rmi $(TAG)
+	-docker rmi $(IMAGE_REPO)
 
 .PHONY: clean-k8s
 clean-k8s:

--- a/scripts/docker_publish.sh
+++ b/scripts/docker_publish.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -o errexit
+
+IMAGE_REPO=${IMAGE_REPO:-mirantis/k8s-appcontroller}
+PUBLISH=${PUBLISH:-}
+
+function push-to-docker {
+    if [ -z "$PUBLISH" ]; then
+        echo "Publish is disabled"
+        exit 0
+    fi
+    if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
+         echo "Processing PR $TRAVIS_PULL_REQUEST_BRANCH"
+         exit 0
+    fi
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+    if [ ! -z "$TRAVIS_TAG" ]; then
+        echo "Pushing with tag - $TRAVIS_TAG"
+        docker push $IMAGE_REPO:$TRAVIS_TAG
+        exit 0
+    fi
+    if [ $TRAVIS_BRANCH == "master" ]; then
+        echo "Pushing with tag - latest"
+        docker push $IMAGE_REPO:latest
+        exit 0
+    fi
+    echo "Pushing with tag - $TRAVIS_BRANCH"
+    docker push $IMAGE_REPO:$TRAVIS_BRANCH
+}
+
+push-to-docker
+


### PR DESCRIPTION
After this patch we will publish docker images after selected succesfull builds.

We are running builds both for kubernetes 1.5.2/go1.7 and kubernetes 1.4.8/go1.6
and publish script will be executed after any succesfull build. To avoid ambiguity we will enable
publishing only for build with go1.7.

We will publish image in next cases:
- After build will pass on master branch, we will publish image with tag - latest
- After build will pass on tagged commit, we will publish image with specified tag
- After build will pass on any other branch, we will publish image with name of that branch

We won't be publishing images for each PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/194)
<!-- Reviewable:end -->
