### PR TITLE
Change cmd help name from ac to kubeac

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -37,6 +37,6 @@ func Init() {
 	var format string
 	Wrap.Flags().StringVarP(&format, "format", "f", "yaml", "file format")
 
-	RootCmd = &cobra.Command{Use: "ac"}
+	RootCmd = &cobra.Command{Use: "kubeac"}
 	RootCmd.AddCommand(Bootstrap, run, Wrap, status)
 }


### PR DESCRIPTION
before
```
Usage:
  ac [command]

Available Commands:
  bootstrap   Bootstrap AppController
  get-status  Get status of deployment
  run         Start deployment of AppController graph
  wrap        Echo wrapped k8s object to stdout
```

now
```
Usage:
  kubeac [command]

Available Commands:
  bootstrap   Bootstrap AppController
  get-status  Get status of deployment
  run         Start deployment of AppController graph
  wrap        Echo wrapped k8s object to stdout
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/198)
<!-- Reviewable:end -->
