### PR TITLE
Refactor appcontroller to work as long running controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,19 @@ Load it to k8s:
 
 `kubectl create -f dependencies_file.yaml`
 
-Start appcontroller process:
+Create configmap to start appcontroller deployment workflow:
 
-`kubectl exec k8s-appcontroller ac-run`
+```
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: appcontrollerdeployment
+data:
+  # limit concurrency for appcontroller
+  concurrency: 3
+  # specify label selector
+  selector: ""
+```
 
 You can stop appcontroller process by:
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -15,14 +15,10 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/labels"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
 	"github.com/Mirantis/k8s-AppController/pkg/scheduler"
@@ -30,18 +26,6 @@ import (
 
 func deploy(cmd *cobra.Command, args []string) {
 	var err error
-
-	concurrency, err := cmd.Flags().GetInt("concurrency")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	labelSelector, err := getLabelSelector(cmd)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Println("Using concurrency:", concurrency)
 
 	var url string
 	if len(args) > 0 {
@@ -55,75 +39,17 @@ func deploy(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	sel, err := labels.Parse(labelSelector)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Println("Using label selector:", labelSelector)
-
-	depGraph, err := scheduler.BuildDependencyGraph(c, sel)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Println("Checking for circular dependencies.")
-	cycles := scheduler.DetectCycles(depGraph)
-	if len(cycles) > 0 {
-		message := "Cycles detected, terminating:\n"
-		for _, cycle := range cycles {
-			keys := make([]string, 0, len(cycle))
-			for _, vertex := range cycle {
-				keys = append(keys, vertex.Key())
-			}
-			message = fmt.Sprintf("%sCycle: %s\n", message, strings.Join(keys, ", "))
-		}
-
-		log.Fatal(message)
-	} else {
-		log.Println("No cycles detected.")
-	}
+	controller := scheduler.NewDeploymentController(c)
 	stopChan := make(chan struct{})
-	scheduler.Create(depGraph, concurrency, stopChan)
-
-	log.Println("Done")
-
-}
-
-func getLabelSelector(cmd *cobra.Command) (string, error) {
-	labelSelector, err := cmd.Flags().GetString("label")
-	if labelSelector == "" {
-		labelSelector = os.Getenv("KUBERNETES_AC_LABEL_SELECTOR")
-	}
-	return labelSelector, err
+	controller.Run(stopChan)
 }
 
 // InitRunCommand returns cobra command for performing AppController graph deployment
 func InitRunCommand() (*cobra.Command, error) {
-	run := &cobra.Command{
+	return &cobra.Command{
 		Use:   "run",
 		Short: "Start deployment of AppController graph",
 		Long:  "Start deployment of AppController graph",
 		Run:   deploy,
-	}
-
-	var labelSelector string
-	run.Flags().StringVarP(&labelSelector, "label", "l", "", "Label selector. Overrides KUBERNETES_AC_LABEL_SELECTOR env variable in AppController pod.")
-
-	concurrencyString := os.Getenv("KUBERNETES_AC_CONCURRENCY")
-
-	var err error
-	var concurrencyDefault int
-	if len(concurrencyString) > 0 {
-		concurrencyDefault, err = strconv.Atoi(concurrencyString)
-		if err != nil {
-			log.Printf("KUBERNETES_AC_CONCURRENCY is set to '%s' but it does not look like an integer: %v",
-				concurrencyString, err)
-			concurrencyDefault = 0
-		}
-	}
-	var concurrency int
-	run.Flags().IntVarP(&concurrency, "concurrency", "c", concurrencyDefault, "concurrency")
-	return run, err
+	}, nil
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -46,13 +46,10 @@ func TestLabelFlag(t *testing.T) {
 	cmd, _ := InitRunCommand()
 
 	val := "TEST_KEY=TEST_VALUE"
-	val2 := "TEST_OTHER_KEY=TEST_OTHER_VALUE"
 	os.Setenv("KUBERNETES_AC_LABEL_SELECTOR", val)
-	cmd.Flags().Parse([]string{"-l", val2})
-
 	label, _ := getLabelSelector(cmd)
 
-	if label != val2 {
-		t.Errorf("label selector should be equal to `%s`, is `%s` instead", val2, label)
+	if label != val {
+		t.Errorf("label selector should be equal to `%s`, is `%s` instead", val, label)
 	}
 }

--- a/cmd/get-status.go
+++ b/cmd/get-status.go
@@ -27,6 +27,14 @@ import (
 	"k8s.io/client-go/pkg/labels"
 )
 
+func getLabelSelector(cmd *cobra.Command) (string, error) {
+	labelSelector, err := cmd.Flags().GetString("label")
+	if labelSelector == "" {
+		labelSelector = os.Getenv("KUBERNETES_AC_LABEL_SELECTOR")
+	}
+	return labelSelector, err
+}
+
 // GetStatus is a command that prints the deployment status
 func getStatus(cmd *cobra.Command, args []string) {
 	var err error

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/errors"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/runtime"
 	"k8s.io/client-go/pkg/util/intstr"
@@ -97,6 +98,22 @@ var _ = Describe("Basic Suite", func() {
 		framework.Run()
 		By("Verifying that second pod will enter running state")
 		testutils.WaitForPod(framework.Clientset, framework.Namespace.Name, pod2.Name, v1.PodRunning)
+	})
+
+	It("Deployment should finish even if appcontroller pod was terminated", func() {
+		framework.DeletePod()
+		By("Creating resource definition with single pod")
+		pod1 := PodPause("pod1")
+		framework.WrapAndCreate(pod1)
+		framework.Run()
+		By("Verify that pod is consistently not found")
+		Consistently(func() bool {
+			_, err := framework.Client.Pods().Get(pod1.Name)
+			return errors.IsNotFound(err)
+		}, 5*time.Second, 1*time.Second).Should(BeTrue(), "Pod was unexpectadly created")
+		By("Recreate appcontroller pod and verify that pod was successfully created")
+		framework.Prepare()
+		testutils.WaitForPod(framework.Clientset, framework.Namespace.Name, pod1.Name, v1.PodRunning)
 	})
 
 	Describe("Failure handling - subgraph", func() {

--- a/e2e/utils/appcmanager.go
+++ b/e2e/utils/appcmanager.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	controlName    = "AppcontrollerDeployment"
+	controlName    = "appcontrollerdeployment"
 	concurrencyKey = "concurrency"
 	selector       = "selector"
 )

--- a/e2e/utils/appcmanager.go
+++ b/e2e/utils/appcmanager.go
@@ -23,13 +23,15 @@ import (
 	"github.com/Mirantis/k8s-AppController/pkg/client"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/errors"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
 const (
-	controlName    = "appcontrollerdeployment"
-	concurrencyKey = "concurrency"
-	selector       = "selector"
+	controlName      = "appcontrollerdeployment"
+	concurrencyKey   = "concurrency"
+	selector         = "selector"
+	appcontrollerPod = "k8s-appcontroller"
 )
 
 type AppControllerManager struct {
@@ -53,10 +55,20 @@ func (a *AppControllerManager) Run() {
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func (a *AppControllerManager) DeletePod() {
+	By("Removing pod " + appcontrollerPod)
+	err := a.Client.Pods().Delete(appcontrollerPod, nil)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() bool {
+		_, err := a.Client.Pods().Get(appcontrollerPod)
+		return errors.IsNotFound(err)
+	}, 20*time.Second, 1*time.Second).Should(BeTrue(), "Appcontroller pod wasn't removed in time")
+}
+
 func (a *AppControllerManager) Prepare() {
 	appControllerObj := &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "k8s-appcontroller",
+			Name: appcontrollerPod,
 			Annotations: map[string]string{
 				"pod.alpha.kubernetes.io/init-containers": `[{"name": "kubeac-bootstrap", "image": "mirantis/k8s-appcontroller", "imagePullPolicy": "Never", "command": ["kubeac", "bootstrap", "/opt/kubeac/manifests"]}]`,
 			},

--- a/examples/extended/create.sh
+++ b/examples/extended/create.sh
@@ -40,5 +40,5 @@ cat serviceaccount.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | 
 
 cat deployment.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-$KUBECTL_NAME exec k8s-appcontroller ac-run
+$KUBECTL_NAME create -f ../../manifests/cfg.yaml
 $KUBECTL_NAME logs -f k8s-appcontroller

--- a/examples/extended/delete.sh
+++ b/examples/extended/delete.sh
@@ -40,3 +40,4 @@ cat deployment.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUB
 cat pvc.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME delete -f -
 
 $KUBECTL_NAME delete -f ../../manifests/appcontroller.yaml
+$KUBECTL_NAME delete -f ../../manifests/cfg.yaml

--- a/examples/on-error-subgraph/delete.sh
+++ b/examples/on-error-subgraph/delete.sh
@@ -8,3 +8,4 @@ cat pod.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap pod1 | $KUBEC
 cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap pod2 | $KUBECTL_NAME delete -f -
 
 $KUBECTL_NAME delete -f ../../appcontroller.yaml
+$KUBECTL_NAME delete -f ../../cfg.yaml

--- a/examples/services/create.sh
+++ b/examples/services/create.sh
@@ -17,6 +17,5 @@ cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_N
 cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 cat pod4.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-$KUBECTL_NAME exec k8s-appcontroller ac-run
-
+$KUBECTL_NAME create -f ../../manifests/appcontroller.yaml
 $KUBECTL_NAME logs -f k8s-appcontroller

--- a/examples/simple/create.sh
+++ b/examples/simple/create.sh
@@ -30,5 +30,4 @@ echo "cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap pod3 |
 cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
 echo "Here we are running appcontroller binary itself. As the log will say, it retrieves dependencies and resource definitions from the k8s cluster and creates underlying objects accordingly."
-echo "$KUBECTL_NAME exec k8s-appcontroller ac-run"
-$KUBECTL_NAME exec k8s-appcontroller ac-run
+$KUBECTL_NAME create -f ../../manifests/cfg.yaml

--- a/examples/simple/create.sh
+++ b/examples/simple/create.sh
@@ -29,5 +29,4 @@ cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_N
 echo "cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap pod3 | $KUBECTL_NAME create -f -"
 cat pod3.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-echo "Here we are running appcontroller binary itself. As the log will say, it retrieves dependencies and resource definitions from the k8s cluster and creates underlying objects accordingly."
 $KUBECTL_NAME create -f ../../manifests/cfg.yaml

--- a/examples/timeout/create.sh
+++ b/examples/timeout/create.sh
@@ -11,5 +11,5 @@ cat pod.yaml | $KUBECTL_NAME create -f -
 cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 cat timedout-pod.yaml | $KUBECTL_NAME create -f -
 
-$KUBECTL_NAME exec k8s-appcontroller ac-run
+$KUBECTL_NAME create -f ../../manifests/cfg.yaml
 $KUBECTL_NAME logs -f k8s-appcontroller

--- a/examples/timeout/delete.sh
+++ b/examples/timeout/delete.sh
@@ -9,3 +9,4 @@ cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_N
 cat timedout-pod.yaml | $KUBECTL_NAME delete -f -
 
 $KUBECTL_NAME delete -f ../../manifests/appcontroller.yaml
+$KUBECTL_NAME delete -f ../../manifests/cfg.yaml

--- a/manifests/appcontroller.yaml
+++ b/manifests/appcontroller.yaml
@@ -10,7 +10,7 @@ spec:
   - name: kubeac
     image: mirantis/k8s-appcontroller
     imagePullPolicy: IfNotPresent
-    command:  ["/usr/bin/run_runit"]
+    command:  ["kubeac", "run"]
     env:
     - name: KUBERNETES_AC_LABEL_SELECTOR
       value: ""

--- a/manifests/cfg.yaml
+++ b/manifests/cfg.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: appcontrollerdeployment
+data:
+  concurrency: 3
+  selector: ""

--- a/pkg/scheduler/controller.go
+++ b/pkg/scheduler/controller.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	controlName    = "AppcontrollerDeployment"
+	controlName    = "appcontrollerdeployment"
 	concurrencyKey = "concurrency"
 	selector       = "selector"
 )

--- a/pkg/scheduler/controller.go
+++ b/pkg/scheduler/controller.go
@@ -1,0 +1,121 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/Mirantis/k8s-AppController/pkg/client"
+
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/fields"
+	"k8s.io/client-go/pkg/labels"
+	"k8s.io/client-go/pkg/runtime"
+	"k8s.io/client-go/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	controlName    = "AppcontrollerDeployment"
+	concurrencyKey = "concurrency"
+	selector       = "selector"
+)
+
+func singleObjectOpts() v1.ListOptions {
+	return v1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", controlName).String(),
+	}
+}
+
+func NewDeploymentController(appc client.Interface) cache.ControllerInterface {
+	opts := singleObjectOpts()
+	var stopChan chan struct{}
+	_, cfgController := cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+				return appc.ConfigMaps().List(opts)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return appc.ConfigMaps().Watch(opts)
+			},
+		},
+		&api.ConfigMap{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				cfg := obj.(*api.ConfigMap)
+				stopChan = make(chan struct{})
+				var concurrency int
+				concurrencyVal, ok := cfg.Data[concurrencyKey]
+				if !ok {
+					concurrency = 1
+				} else {
+					var err error
+					concurrency, err = strconv.Atoi(concurrencyVal)
+					if err != nil {
+						fmt.Println(err)
+					}
+					return
+				}
+				labelSelector, ok := cfg.Data[selector]
+				if !ok {
+					labelSelector = ""
+				}
+				depGraph := initializeDependencyGraph(appc, labelSelector)
+				fmt.Println("Running deployment with labels ", labelSelector)
+				go Create(depGraph, concurrency, stopChan)
+			},
+			DeleteFunc: func(_ interface{}) {
+				close(stopChan)
+			},
+		},
+	)
+	return cfgController
+}
+
+func initializeDependencyGraph(c client.Interface, labelSelector string) DependencyGraph {
+	sel, err := labels.Parse(labelSelector)
+	if err != nil {
+		log.Println(err)
+	}
+	log.Println("Using label selector:", labelSelector)
+
+	depGraph, err := BuildDependencyGraph(c, sel)
+	if err != nil {
+		log.Println(err)
+	}
+
+	log.Println("Checking for circular dependencies.")
+	cycles := DetectCycles(depGraph)
+	if len(cycles) > 0 {
+		message := "Cycles detected, terminating:\n"
+		for _, cycle := range cycles {
+			keys := make([]string, 0, len(cycle))
+			for _, vertex := range cycle {
+				keys = append(keys, vertex.Key())
+			}
+			message = fmt.Sprintf("%sCycle: %s\n", message, strings.Join(keys, ", "))
+		}
+
+		log.Println(message)
+	} else {
+		log.Println("No cycles detected.")
+	}
+	return depGraph
+}

--- a/pkg/scheduler/controller_test.go
+++ b/pkg/scheduler/controller_test.go
@@ -1,0 +1,54 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
+	fcache "k8s.io/client-go/tools/cache/testing"
+
+	"github.com/Mirantis/k8s-AppController/pkg/mocks"
+)
+
+func TestDeploymentWorkflow(t *testing.T) {
+	c := mocks.NewClient()
+	source := fcache.NewFakeControllerSource()
+
+	waitCh := make(chan struct{})
+	var stopCh <-chan struct{}
+	f := func(_ DependencyGraph, _ int, stopChan <-chan struct{}) {
+		t.Log("Closing wait chanell")
+		waitCh <- struct{}{}
+		stopCh = stopChan
+	}
+
+	controller := newDeploymentController(c, source, f)
+	controllerCh := make(chan struct{})
+	defer close(controllerCh)
+	go controller.Run(controllerCh)
+
+	cfg := &v1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{Name: controlName},
+		Data: map[string]string{
+			concurrencyKey: "0",
+			selector:       "",
+		},
+	}
+	source.Add(cfg)
+	<-waitCh
+	source.Delete(cfg)
+	<-stopCh
+}


### PR DESCRIPTION
Instead of running ac-run inside of the appcontroller pod user will
have to create documented config map with several fields (concurrency, labels selector).

appcontroller process will listen to changes for that config map and run deployment graph
processing, on deletion of configmap we will terminate deployment workflow.

It will allow us to provide guarantees that workflow will be finished even if appcontroller
pod will crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/214)
<!-- Reviewable:end -->
