### PR TITLE
Exportable flows 

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 	"github.com/Mirantis/k8s-AppController/pkg/scheduler"
 	"github.com/spf13/cobra"
 
@@ -62,7 +63,7 @@ func deploy(cmd *cobra.Command, args []string) {
 	log.Println("Using label selector:", labelSelector)
 
 	sched := scheduler.New(c, sel, concurrency)
-	depGraph, err := sched.BuildDependencyGraph()
+	depGraph, err := sched.BuildDependencyGraph(interfaces.DefaultFlowName, make(map[string]string))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/get-status.go
+++ b/cmd/get-status.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 	"github.com/Mirantis/k8s-AppController/pkg/scheduler"
 	"github.com/spf13/cobra"
 
@@ -62,7 +63,7 @@ func getStatus(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	sched := scheduler.New(c, sel, 0)
-	graph, err := sched.BuildDependencyGraph()
+	graph, err := sched.BuildDependencyGraph(interfaces.DefaultFlowName, make(map[string]string))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/get-status.go
+++ b/cmd/get-status.go
@@ -63,7 +63,7 @@ func getStatus(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	sched := scheduler.New(c, sel, 0)
-	graph, err := sched.BuildDependencyGraph(interfaces.DefaultFlowName, make(map[string]string))
+	graph, err := sched.BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/e2e/example_runner.go
+++ b/e2e/example_runner.go
@@ -107,7 +107,7 @@ func (f *ExamplesFramework) VerifyStatus() {
 	Eventually(
 		func() bool {
 			depGraph, err := scheduler.New(f.Client, nil, 0).BuildDependencyGraph(
-				interfaces.DefaultFlowName, nil)
+				interfaces.DependencyGraphOptions{})
 			if err != nil {
 				return false
 			}

--- a/e2e/example_runner.go
+++ b/e2e/example_runner.go
@@ -106,7 +106,8 @@ func (f *ExamplesFramework) VerifyStatus() {
 	var depReport report.DeploymentReport
 	Eventually(
 		func() bool {
-			depGraph, err := scheduler.New(f.Client, nil, 0).BuildDependencyGraph()
+			depGraph, err := scheduler.New(f.Client, nil, 0).BuildDependencyGraph(
+				interfaces.DefaultFlowName, nil)
 			if err != nil {
 				return false
 			}

--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -31,4 +31,8 @@ type Flow struct {
 	// it would mean that creating a job is what the flow does. Otherwise it would mean that the job depends on
 	// the the flow (i.e. it won't be created before everything, the flow consists of)
 	Construction map[string]string `json:"construction,omitempty"`
+
+	// Exported flows can be triggered by the user (through the CLI) whereas those that are not
+	// can only be triggered by other flows (including DEFAULT flow which is exported by-default)
+	Exported bool `json:"exported,omitempty"`
 }

--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/unversioned"
+)
+
+type Flow struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard object metadata
+	api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Specifies (partial) label that is used to identify dependencies that belong to
+	// the construction path of the Flow (i.e. Flows can have different paths for construction and destruction).
+	// For example, if we have flow->job dependency, if this dependency were to confirm to the Construction label
+	// it would mean that creating a job is what the flow does. Otherwise it would mean that the job depends on
+	// the the flow (i.e. it won't be created before everything, the flow consists of)
+	Construction map[string]string `json:"construction,omitempty"`
+}

--- a/pkg/client/resdef.go
+++ b/pkg/client/resdef.go
@@ -51,6 +51,7 @@ type ResourceDefinition struct {
 	Secret                *v1.Secret                `json:"secret,omitempty"`
 	Deployment            *v1beta1.Deployment       `json:"deployment, omitempty"`
 	PersistentVolumeClaim *v1.PersistentVolumeClaim `json:"persistentvolumeclaim, omitempty"`
+	Flow                  *Flow                     `json:"flow, omitempty"`
 }
 
 type ResourceDefinitionList struct {

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -75,8 +75,15 @@ type GraphContext interface {
 	Scheduler() Scheduler
 	Args() map[string]string
 	Graph() DependencyGraph
+	GraphOptions() DependencyGraphOptions
+}
+
+type DependencyGraphOptions struct {
+	FlowName     string
+	Args         map[string]string
+	ExportedOnly bool
 }
 
 type Scheduler interface {
-	BuildDependencyGraph(flowName string, args map[string]string) (DependencyGraph, error)
+	BuildDependencyGraph(options DependencyGraphOptions) (DependencyGraph, error)
 }

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -26,6 +26,8 @@ const (
 	ResourceError    ResourceStatus = "error"
 )
 
+const DefaultFlowName = "DEFAULT"
+
 // BaseResource is an interface for AppController supported resources
 type BaseResource interface {
 	Key() string
@@ -71,9 +73,10 @@ type DependencyGraph interface {
 
 type GraphContext interface {
 	Scheduler() Scheduler
+	Args() map[string]string
 	Graph() DependencyGraph
 }
 
 type Scheduler interface {
-	BuildDependencyGraph() (DependencyGraph, error)
+	BuildDependencyGraph(flowName string, args map[string]string) (DependencyGraph, error)
 }

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -33,6 +33,7 @@ func init() {
 		configMapTemplateFactory{},
 		daemonSetTemplateFactory{},
 		deploymentTemplateFactory{},
+		flowTemplateFactory{},
 		jobTemplateFactory{},
 		persistentVolumeClaimTemplateFactory{},
 		petSetTemplateFactory{},

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -69,7 +69,10 @@ func (f Flow) Key() string {
 
 // Triggers the flow deployment like it was the resource creation
 func (f *Flow) Create() error {
-	graph, err := f.scheduler.BuildDependencyGraph(f.flow.Name, map[string]string{})
+	options := interfaces.DependencyGraphOptions{
+		FlowName: f.flow.Name,
+	}
+	graph, err := f.scheduler.BuildDependencyGraph(options)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"errors"
+	"log"
+
+	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
+	"github.com/Mirantis/k8s-AppController/pkg/report"
+)
+
+type Flow struct {
+	Base
+	flow      *client.Flow
+	scheduler interfaces.Scheduler
+	status    interfaces.ResourceStatus
+}
+
+type flowTemplateFactory struct{}
+
+// Returns wrapped resource name if it was a flow
+func (flowTemplateFactory) ShortName(definition client.ResourceDefinition) string {
+	if definition.Flow == nil {
+		return ""
+	}
+	return definition.Flow.Name
+}
+
+// k8s resource kind that this fabric supports
+func (flowTemplateFactory) Kind() string {
+	return "flow"
+}
+
+// New returns a new object wrapped as Resource
+func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
+	return report.SimpleReporter{
+		BaseResource: &Flow{
+			Base:      Base{def.Meta},
+			flow:      def.Flow,
+			scheduler: gc.Scheduler(),
+			status:    interfaces.ResourceNotReady,
+		}}
+}
+
+// NewExisting returns a new object based on existing one wrapped as Resource
+func (flowTemplateFactory) NewExisting(name string, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
+	log.Fatal("Cannot depend on flow that has no resource definition")
+	return nil
+}
+
+// Identifier of the object
+func (f Flow) Key() string {
+	return "flow/" + f.flow.Name
+}
+
+// Triggers the flow deployment like it was the resource creation
+func (f *Flow) Create() error {
+	graph, err := f.scheduler.BuildDependencyGraph(f.flow.Name, map[string]string{})
+	if err != nil {
+		return err
+	}
+	go func() {
+		stopChan := make(chan struct{})
+		graph.Deploy(stopChan)
+		f.status = interfaces.ResourceReady
+	}()
+	return nil
+}
+
+// Deletes resources allocated to the flow
+func (f Flow) Delete() error {
+	return errors.New("Not supported yet")
+}
+
+// Current status of the flow deployment
+func (f Flow) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+	return f.status, nil
+}

--- a/pkg/scheduler/dependency_graph.go
+++ b/pkg/scheduler/dependency_graph.go
@@ -45,6 +45,11 @@ func (gc GraphContext) Scheduler() interfaces.Scheduler {
 	return gc.scheduler
 }
 
+// Returns argument values available in the current graph context
+func (gc GraphContext) Args() map[string]string {
+	return gc.args
+}
+
 // Returns the currently running dependency graph
 func (gc GraphContext) Graph() interfaces.DependencyGraph {
 	return gc.graph
@@ -78,21 +83,24 @@ func groupDependencies(dependencies []client.Dependency,
 		isDependant[dependency.Child] = true
 	}
 
-	rootDependencies := []client.Dependency{}
-	addResource := func(name string) {
-		if !isDependant[name] {
-			rootDependencies = append(rootDependencies, client.Dependency{Parent: "", Child: name})
-			isDependant[name] = true
+	defaultFlowName := "flow/" + interfaces.DefaultFlowName
+	if defaultFlow := result[defaultFlowName]; defaultFlow == nil {
+		defaultFlow = []client.Dependency{}
+		addResource := func(name string) {
+			if !strings.HasPrefix(name, "flow/") && !isDependant[name] {
+				defaultFlow = append(defaultFlow, client.Dependency{Parent: defaultFlowName, Child: name})
+				isDependant[name] = true
+			}
 		}
-	}
 
-	for parent := range result {
-		addResource(parent)
+		for parent := range result {
+			addResource(parent)
+		}
+		for resDef := range resDefs {
+			addResource(resDef)
+		}
+		result[defaultFlowName] = defaultFlow
 	}
-	for resDef := range resDefs {
-		addResource(resDef)
-	}
-	result[""] = rootDependencies
 	return result
 }
 
@@ -119,6 +127,30 @@ func (sched *Scheduler) getResourceDefinitions() (map[string]client.ResourceDefi
 		result[kind+"/"+name] = resDef
 	}
 	return result, nil
+}
+
+func filterDependencies(dependencies map[string][]client.Dependency, parent string,
+	flow *client.Flow) []client.Dependency {
+
+	children := dependencies[parent]
+	var result []client.Dependency
+	for _, dep := range children {
+		if canDependencyBelongToFlow(&dep, flow) {
+			result = append(result, dep)
+		}
+	}
+	return result
+}
+
+func canDependencyBelongToFlow(dep *client.Dependency, flow *client.Flow) bool {
+	if flow != nil {
+		for k, v := range flow.Construction {
+			if dep.Labels[k] != v {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // newScheduledResource is a constructor for ScheduledResource
@@ -166,7 +198,7 @@ func keyParts(key string) (kind, name string, err error) {
 	return parts[0], parts[1], nil
 }
 
-// BuildDependencyGraph loads dependencies data and creates the DependencyGraph
+// Constructor of DependencyGraph
 func NewDependencyGraph(sched *Scheduler) *DependencyGraph {
 	return &DependencyGraph{
 		graph:     make(map[string]*ScheduledResource),
@@ -175,12 +207,19 @@ func NewDependencyGraph(sched *Scheduler) *DependencyGraph {
 }
 
 // BuildDependencyGraph loads dependencies data and creates the DependencyGraph
-func (sched *Scheduler) BuildDependencyGraph() (interfaces.DependencyGraph, error) {
+func (sched *Scheduler) BuildDependencyGraph(flowName string,
+	args map[string]string) (interfaces.DependencyGraph, error) {
 
 	log.Println("Getting resource definitions")
 	resDefs, err := sched.getResourceDefinitions()
 	if err != nil {
 		return nil, err
+	}
+
+	fullFlowName := "flow/" + flowName
+	flow, ok := resDefs[fullFlowName]
+	if !ok && flowName != interfaces.DefaultFlowName || ok && flow.Flow == nil {
+		return nil, fmt.Errorf("flow %s is not found", flowName)
 	}
 
 	log.Println("Getting dependencies")
@@ -198,29 +237,40 @@ func (sched *Scheduler) BuildDependencyGraph() (interfaces.DependencyGraph, erro
 
 	depGraph := NewDependencyGraph(sched)
 
+	if _, ok := dependencies[fullFlowName]; !ok {
+		log.Println("Flow depGraph is empty")
+		return depGraph, nil
+	}
+
 	queue := list.New()
-	queue.PushFront("")
+	queue.PushFront(fullFlowName)
 	context := GraphContext{scheduler: sched, graph: depGraph}
 
 	for e := queue.Front(); e != nil; e = e.Next() {
 		el := e.Value.(string)
 
-		deps := dependencies[el]
+		deps := filterDependencies(dependencies, el, flow.Flow)
 		parent := depGraph.graph[el]
 
 		for _, dep := range deps {
+			if parent != nil && strings.HasPrefix(parent.Key(), "flow/") {
+				parentFlow := resDefs[dep.Parent]
+				if parentFlow.Flow != nil && canDependencyBelongToFlow(&dep, parentFlow.Flow) {
+					continue
+				}
+			}
 			sr := depGraph.graph[dep.Child]
 			if sr == nil {
 				kind, name, err := keyParts(dep.Child)
-				log.Printf("Adding resource %s to the graph", dep.Child)
+				log.Printf("Adding resource %s to the flow dependency graph %s", dep.Child, flowName)
 
 				sr, err = sched.newScheduledResource(kind, name, resDefs, context)
 				if err != nil {
 					return nil, err
 				}
+				depGraph.graph[dep.Child] = sr
 			}
 
-			depGraph.graph[dep.Child] = sr
 			if parent != nil {
 				sr.Requires = append(sr.Requires, parent)
 				parent.RequiredBy = append(parent.RequiredBy, sr)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -38,7 +38,7 @@ func TestBuildDependencyGraph(t *testing.T) {
 
 	sched := New(c, nil, 0)
 
-	dg, err := sched.BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	dg, err := sched.BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Error(err)
 		return
@@ -298,7 +298,7 @@ func TestLimitConcurrency(t *testing.T) {
 		counter := mocks.NewCounterWithMemo()
 
 		sched := &Scheduler{concurrency: concurrency}
-		depGraph := NewDependencyGraph(sched)
+		depGraph := NewDependencyGraph(sched, interfaces.DependencyGraphOptions{})
 
 		for i := 0; i < 15; i++ {
 			key := fmt.Sprintf("resource%d", i)
@@ -320,7 +320,7 @@ func TestLimitConcurrency(t *testing.T) {
 }
 
 func TestStopBeforeDeploymentStarted(t *testing.T) {
-	depGraph := NewDependencyGraph(&Scheduler{})
+	depGraph := NewDependencyGraph(&Scheduler{}, interfaces.DependencyGraphOptions{})
 	sr := &ScheduledResource{
 		Resource: report.SimpleReporter{BaseResource: mocks.NewResource("fake1", "not ready")},
 	}
@@ -371,7 +371,7 @@ func TestGraphAllResourceTypes(t *testing.T) {
 		mocks.MakeDependency("pod/ready-1", "serviceaccount/sa-1"),
 	)
 
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestGraphAllResourceTypes(t *testing.T) {
 
 func TestEmptyStatus(t *testing.T) {
 	c := mocks.NewClient()
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestPreparedStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/1", "job/2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestRunningStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/ready-1", "job/2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,7 +452,7 @@ func TestFinishedStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/ready-1", "job/ready-2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestGraph(t *testing.T) {
 		mocks.MakeDependency("job/ready-2", "job/1"),
 		mocks.MakeDependency("job/3", "job/1"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -38,7 +38,7 @@ func TestBuildDependencyGraph(t *testing.T) {
 
 	sched := New(c, nil, 0)
 
-	dg, err := sched.BuildDependencyGraph()
+	dg, err := sched.BuildDependencyGraph(interfaces.DefaultFlowName, nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -371,7 +371,7 @@ func TestGraphAllResourceTypes(t *testing.T) {
 		mocks.MakeDependency("pod/ready-1", "serviceaccount/sa-1"),
 	)
 
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph()
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestGraphAllResourceTypes(t *testing.T) {
 
 func TestEmptyStatus(t *testing.T) {
 	c := mocks.NewClient()
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph()
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestPreparedStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/1", "job/2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph()
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestRunningStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/ready-1", "job/2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph()
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,7 +452,7 @@ func TestFinishedStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/ready-1", "job/ready-2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph()
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestGraph(t *testing.T) {
 		mocks.MakeDependency("job/ready-2", "job/1"),
 		mocks.MakeDependency("job/3", "job/1"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph()
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* Ability to specify flow as exported (exported: true)
* If the flow is exported it can be deployed with "kubeac run flowName"
* BuildDependencyGraph arguments were refactored into structure.
   The value provided is also accessible by resource classes via GraphContext

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/223)
<!-- Reviewable:end -->
