### PR TITLE
Fixed docker publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: go
 services:
-    - docker
+  - docker
 go:
   - 1.6
   - 1.7
@@ -21,5 +21,4 @@ script:
   - go get github.com/Masterminds/glide
   - make test
   - make e2e
-after_success:
   - make docker-publish

--- a/scripts/docker_publish.sh
+++ b/scripts/docker_publish.sh
@@ -1,33 +1,73 @@
 #!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+set -o xtrace
+set -o pipefail
 set -o errexit
+set -o nounset
 
+
+TRAVIS_PULL_REQUEST_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-}
+TRAVIS_TEST_RESULT=${TRAVIS_TEST_RESULT:-}
+TRAVIS_BRANCH=${TRAVIS_BRANCH:-}
 IMAGE_REPO=${IMAGE_REPO:-mirantis/k8s-appcontroller}
+TRAVIS_TAG=${TRAVIS_TAG:-}
 PUBLISH=${PUBLISH:-}
 
+
 function push-to-docker {
-    if [ -z "$PUBLISH" ]; then
-        echo "Publish is disabled"
-        exit 0
-    fi
-    if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
-         echo "Processing PR $TRAVIS_PULL_REQUEST_BRANCH"
-         exit 0
-    fi
-    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-    if [ ! -z "$TRAVIS_TAG" ]; then
-        echo "Pushing with tag - $TRAVIS_TAG"
-        docker push $IMAGE_REPO:$TRAVIS_TAG
-        exit 0
-    fi
-    if [ $TRAVIS_BRANCH == "master" ]; then
-        echo "Pushing with tag - latest"
-        docker push $IMAGE_REPO:latest
-        exit 0
-    fi
-    echo "Pushing with tag - $TRAVIS_BRANCH"
-    docker push $IMAGE_REPO:$TRAVIS_BRANCH
+  if [ -z "${PUBLISH}" ]; then
+    echo "Publish is disabled."
+    exit 0
+  fi
+
+  if [ -z "${TRAVIS_TEST_RESULT}" ]; then
+    echo "TRAVIS_TEST_RESULT is not set!"
+    exit 1
+  else
+      if [ "${TRAVIS_TEST_RESULT}" -ne 0 ]; then
+        echo "Some of the previous steps ended with an errors! The build is broken!"
+        exit 1
+      fi
+  fi
+
+  if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "" ]; then
+    echo "Processing PR ${TRAVIS_PULL_REQUEST_BRANCH}"
+    exit 0
+  else
+      set +o xtrace
+      docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+      set -o xtrace
+  fi
+
+  if [ ! -z "${TRAVIS_TAG}" ]; then
+    echo "Pushing with tag - ${TRAVIS_TAG}"
+    docker tag "${IMAGE_REPO}" "${IMAGE_REPO}":"${TRAVIS_TAG}"
+    docker push "${IMAGE_REPO}":"${TRAVIS_TAG}"
+    exit
+  fi
+
+  if [ "${TRAVIS_BRANCH}" == "master" ]; then
+    echo "Pushing with tag - latest"
+    docker push "${IMAGE_REPO}":latest
+    exit
+  fi
+
+  echo "Pushing with tag - ${TRAVIS_BRANCH}"
+  docker tag "${IMAGE_REPO}" "${IMAGE_REPO}":"${TRAVIS_BRANCH}"
+  docker push "${IMAGE_REPO}":"${TRAVIS_BRANCH}"
 }
 
 push-to-docker
-

--- a/scripts/docker_publish.sh
+++ b/scripts/docker_publish.sh
@@ -37,22 +37,22 @@ function push-to-docker {
     echo "TRAVIS_TEST_RESULT is not set!"
     exit 1
   else
-      if [ "${TRAVIS_TEST_RESULT}" -ne 0 ]; then
-        echo "Some of the previous steps ended with an errors! The build is broken!"
-        exit 1
-      fi
+    if [ "${TRAVIS_TEST_RESULT}" -ne 0 ]; then
+      echo "Some of the previous steps ended with an errors! The build is broken!"
+      exit 1
+    fi
   fi
 
-  if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "" ]; then
+  if [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
     echo "Processing PR ${TRAVIS_PULL_REQUEST_BRANCH}"
     exit 0
   else
-      set +o xtrace
-      docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-      set -o xtrace
+    set +o xtrace
+    docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+    set -o xtrace
   fi
 
-  if [ ! -z "${TRAVIS_TAG}" ]; then
+  if [ -n "${TRAVIS_TAG}" ]; then
     echo "Pushing with tag - ${TRAVIS_TAG}"
     docker tag "${IMAGE_REPO}" "${IMAGE_REPO}":"${TRAVIS_TAG}"
     docker push "${IMAGE_REPO}":"${TRAVIS_TAG}"

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
+# Copyright 2017 Mirantis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+set -o xtrace
+set -o pipefail
 set -o errexit
 set -o nounset
-set -o pipefail
-set -o xtrace
+
 
 IMAGE_REPO=${IMAGE_REPO:-mirantis/k8s-appcontroller}
 IMAGE_TAG=${IMAGE_TAG:-latest}
@@ -14,20 +28,18 @@ SLAVE_PATTERN=${SLAVE_PATTERN:-"kube-node-"}
 
 
 function import-image {
-    docker save ${IMAGE_REPO}:${IMAGE_TAG} -o "${TMP_IMAGE_PATH}"
+  docker save -o "${TMP_IMAGE_PATH}" "${IMAGE_REPO}":"${IMAGE_TAG}"
 
-    if [ -n "$MASTER_NAME" ]; then
-        docker cp "${TMP_IMAGE_PATH}" kube-master:/image.tar
-        docker exec -ti "${MASTER_NAME}" docker load -i /image.tar
-    fi
+  if [ -n "${MASTER_NAME}" ]; then
+    docker cp "${TMP_IMAGE_PATH}" "${MASTER_NAME}":/image.tar
+    docker exec -ti "${MASTER_NAME}" docker load -i /image.tar
+  fi
 
-    for i in `seq 1 "${NUM_NODES}"`;
-    do
-        docker cp "${TMP_IMAGE_PATH}" "${SLAVE_PATTERN}$i":/image.tar
-        docker exec -ti "${SLAVE_PATTERN}$i" docker load -i /image.tar
-    done
-    set +o xtrace
-    echo "Finished copying docker image to dind nodes"
+  for node in $(seq 1 "${NUM_NODES}"); do
+    docker cp "${TMP_IMAGE_PATH}" "${SLAVE_PATTERN}""${node}":/image.tar
+    docker exec -ti "${SLAVE_PATTERN}""${node}" docker load -i /image.tar
+  done
+  echo "Finished copying docker image to dind nodes"
 }
 
 import-image


### PR DESCRIPTION
- Add copyright notices

- Currently, CI pushing images only with latest tag:
  https://travis-ci.org/Mirantis/k8s-AppController/jobs/203410745#L1998-L2001
  No one paid attention to this, because the "after_success" step failure
  doesn't fail build:
  https://github.com/travis-ci/travis-ci/issues/758
  And at the moment a good fix is to use this as the last entry of
  "script" step instead of "after_success" step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/228)
<!-- Reviewable:end -->
