### PR TITLE
Resources with generated name

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -115,7 +115,7 @@ func bootstrap(cmd *cobra.Command, args []string) {
 
 	checkVersion(c)
 
-	manifests := [...]string{"dependencies.json", "resdefs.json"}
+	manifests := [...]string{"dependencies.json", "resdefs.json", "flowdeployments.json"}
 
 	for _, manifest := range manifests {
 		dependency := getDependencyFromPath(thirdPartyResourcesPath + "/" + manifest)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -95,6 +95,7 @@ func deploy(cmd *cobra.Command, args []string) {
 		Args:                flowArgMap,
 		AllowUndeclaredArgs: anyArgs,
 	}
+
 	log.Println("Going to deploy flow:", flowName)
 	depGraph, err := sched.BuildDependencyGraph(options)
 	if err != nil {
@@ -133,7 +134,8 @@ func InitRunCommand() (*cobra.Command, error) {
 	}
 
 	var labelSelector string
-	run.Flags().StringVarP(&labelSelector, "label", "l", "", "Label selector. Overrides KUBERNETES_AC_LABEL_SELECTOR env variable in AppController pod.")
+	run.Flags().StringVarP(&labelSelector, "label", "l", "",
+		"Label selector. Overrides KUBERNETES_AC_LABEL_SELECTOR env variable in AppController pod.")
 
 	run.Flags().Bool("undeclared-args", false, "Allow undeclared arguments")
 

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -28,12 +28,16 @@ type DataExtractor struct {
 	Kind     string "kind"
 	Metadata struct {
 		Name string "name"
+		GenerateName string "generateName"
 	} "metadata"
 }
 
-func normalizeName(name string) string {
+func normalizeName(kind, name string) string {
+	if name == "" {
+		return ""
+	}
 	for k, v := range map[string]string{"$": "", "_": "-"} {
 		name = strings.Replace(name, k, v, -1)
 	}
-	return strings.ToLower(name)
+	return kind + "-" + strings.ToLower(name)
 }

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -14,6 +14,8 @@
 
 package format
 
+import "strings"
+
 // Format is an interface for data formats for wrapper
 type Format interface {
 	ExtractData(k8sObject string) (DataExtractor, error)
@@ -27,4 +29,8 @@ type DataExtractor struct {
 	Metadata struct {
 		Name string "name"
 	} "metadata"
+}
+
+func normalizeName(name string) string {
+	return strings.ToLower(strings.Replace(name, "$", "", -1))
 }

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -32,5 +32,8 @@ type DataExtractor struct {
 }
 
 func normalizeName(name string) string {
-	return strings.ToLower(strings.Replace(name, "$", "", -1))
+	for k, v := range map[string]string{"$": "", "_": "-"} {
+		name = strings.Replace(name, k, v, -1)
+	}
+	return strings.ToLower(name)
 }

--- a/cmd/format/json.go
+++ b/cmd/format/json.go
@@ -39,7 +39,8 @@ func (f JSON) Wrap(k8sObject string) (string, error) {
     "apiVersion": "appcontroller.k8s/v1alpha1",
     "kind": "Definition",
     "metadata": {
-        "name": "` + normalizeName(data.Kind+"-"+data.Metadata.Name) + `"
+        "name": "` + normalizeName(data.Kind, data.Metadata.Name) + `",
+        "generateName": "` + normalizeName(data.Kind, data.Metadata.GenerateName) + `"
     },` + "\n"
 
 	if err != nil {

--- a/cmd/format/json.go
+++ b/cmd/format/json.go
@@ -39,7 +39,7 @@ func (f JSON) Wrap(k8sObject string) (string, error) {
     "apiVersion": "appcontroller.k8s/v1alpha1",
     "kind": "Definition",
     "metadata": {
-        "name": "` + data.Kind + "-" + data.Metadata.Name + `"
+        "name": "` + normalizeName(data.Kind+"-"+data.Metadata.Name) + `"
     },` + "\n"
 
 	if err != nil {

--- a/cmd/format/yaml.go
+++ b/cmd/format/yaml.go
@@ -46,7 +46,8 @@ func (f Yaml) Wrap(k8sObject string) (string, error) {
 		base := `apiVersion: appcontroller.k8s/v1alpha1
 kind: Definition
 metadata:
-  name: ` + normalizeName(data.Kind+"-"+data.Metadata.Name) + "\n"
+  name: ` + normalizeName(data.Kind, data.Metadata.Name) + `
+  generateName: ` + normalizeName(data.Kind, data.Metadata.GenerateName) + "\n"
 		result = append(result, base+data.Kind+":\n"+strings.Trim(o, "\n"))
 	}
 

--- a/cmd/format/yaml.go
+++ b/cmd/format/yaml.go
@@ -46,7 +46,7 @@ func (f Yaml) Wrap(k8sObject string) (string, error) {
 		base := `apiVersion: appcontroller.k8s/v1alpha1
 kind: Definition
 metadata:
-  name: ` + data.Kind + "-" + data.Metadata.Name + "\n"
+  name: ` + normalizeName(data.Kind+"-"+data.Metadata.Name) + "\n"
 		result = append(result, base+data.Kind+":\n"+strings.Trim(o, "\n"))
 	}
 

--- a/cmd/get-status.go
+++ b/cmd/get-status.go
@@ -63,7 +63,7 @@ func getStatus(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	sched := scheduler.New(c, sel, 0)
-	graph, err := sched.BuildDependencyGraph(interfaces.DefaultFlowName, make(map[string]string))
+	graph, err := sched.BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/e2e/example_runner.go
+++ b/e2e/example_runner.go
@@ -107,7 +107,7 @@ func (f *ExamplesFramework) VerifyStatus() {
 	Eventually(
 		func() bool {
 			depGraph, err := scheduler.New(f.Client, nil, 0).BuildDependencyGraph(
-				interfaces.DefaultFlowName, nil)
+				interfaces.DependencyGraphOptions{})
 			if err != nil {
 				return false
 			}

--- a/manifests/flowdeployments.json
+++ b/manifests/flowdeployments.json
@@ -1,0 +1,13 @@
+{
+	"metadata": {
+		"name": "deployment.appcontroller.k8s"
+	},
+	"apiVersion": "extensions/v1beta1",
+	"kind": "ThirdPartyResource",
+	"description": "AppController Flow deployment",
+	"versions": [
+		{
+			"name": "v1alpha1"
+		}
+	]
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -96,6 +96,7 @@ type Interface interface {
 	ResourceDefinitions() ResourceDefinitionsInterface
 
 	IsEnabled(version unversioned.GroupVersion) bool
+	Namespace() string
 }
 
 type Client struct {
@@ -176,6 +177,11 @@ func (c Client) Deployments() v1beta1.DeploymentInterface {
 // PersistentVolumeClaims return K8s PVC client for ac namespace
 func (c Client) PersistentVolumeClaims() corev1.PersistentVolumeClaimInterface {
 	return c.clientset.Core().PersistentVolumeClaims(c.namespace)
+}
+
+// Namespace returns current namespace for the client
+func (c Client) Namespace() string {
+	return c.namespace
 }
 
 // IsEnabled verifies that required group name and group version is registered in API

--- a/pkg/client/dependencies.go
+++ b/pkg/client/dependencies.go
@@ -32,6 +32,7 @@ type Dependency struct {
 	Parent string            `json:"parent"`
 	Child  string            `json:"child"`
 	Meta   map[string]string `json:"meta,omitempty"`
+	Args   map[string]string `json:"args,omitempty"`
 }
 
 type DependencyList struct {

--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -31,4 +31,8 @@ type Flow struct {
 	// it would mean that creating a job is what the flow does. Otherwise it would mean that the job depends on
 	// the the flow (i.e. it won't be created before everything, the flow consists of)
 	Construction map[string]string `json:"construction,omitempty"`
+
+	// Exported flows can be triggered by the user (through the CLI) whereas those that are not
+	// can only be triggered by other flows (including DEFAULT flow which is exported by-default)
+	Exported bool `json:"exported,omitempty"`
 }

--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -35,4 +35,16 @@ type Flow struct {
 	// Exported flows can be triggered by the user (through the CLI) whereas those that are not
 	// can only be triggered by other flows (including DEFAULT flow which is exported by-default)
 	Exported bool `json:"exported,omitempty"`
+
+	// Parameters that the flow can accept (i.e. valid inputs for the flow)
+	Parameters map[string]FlowParameter `json:"parameters,omitempty"`
+}
+
+type FlowParameter struct {
+	// Optional default value for the parameter. If the declared parameter has nil Default then the argument for
+	// this parameter becomes mandatory (i.e. it MUST be provided)
+	Default *string `json:"default,omitempty"`
+
+	// Description of the parameter (help string)
+	Description string `json:"description,omitempty"`
 }

--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -15,8 +15,13 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/rest"
 )
 
 type Flow struct {
@@ -38,6 +43,9 @@ type Flow struct {
 
 	// Parameters that the flow can accept (i.e. valid inputs for the flow)
 	Parameters map[string]FlowParameter `json:"parameters,omitempty"`
+
+	// How many times the flow subgraph should be replicated. <= 0 means 1 flow replica without AC_NAME assigned
+	ReplicaCount int
 }
 
 type FlowParameter struct {
@@ -47,4 +55,125 @@ type FlowParameter struct {
 
 	// Description of the parameter (help string)
 	Description string `json:"description,omitempty"`
+}
+
+type FlowDeployment struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard object metadata
+	api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	FlowName string `json:"flowName,omitempty"`
+}
+
+type FlowDeploymentList struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard list metadata.
+	unversioned.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Items []FlowDeployment `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+type FlowDeploymentsInterface interface {
+	List(opts api.ListOptions) (*FlowDeploymentList, error)
+	Create(flowDeployment *FlowDeployment) (*FlowDeployment, error)
+	Delete(name string, opts *api.DeleteOptions) error
+	Get(name string) (result *FlowDeployment, err error)
+}
+
+type flowdeployments struct {
+	rc        *rest.RESTClient
+	namespace string
+}
+
+func newFlowDeployments(c rest.Config, ns string) (*flowdeployments, error) {
+	rc, err := thirdPartyResourceRESTClient(&c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &flowdeployments{rc, ns}, nil
+}
+
+func (f *flowdeployments) List(opts api.ListOptions) (*FlowDeploymentList, error) {
+	resp, err := f.rc.Get().
+		Namespace(f.namespace).
+		Resource("deployments").
+		LabelsSelectorParam(opts.LabelSelector).
+		DoRaw()
+
+	if err != nil {
+		return nil, err
+	}
+
+	result := &FlowDeploymentList{}
+	err = json.NewDecoder(bytes.NewReader(resp)).Decode(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (f *flowdeployments) Create(flowDeployment *FlowDeployment) (result *FlowDeployment, err error) {
+	result = &FlowDeployment{}
+	data, err := f.rc.Post().
+		Resource("deployments").
+		Namespace(f.namespace).
+		Body(flowDeployment).
+		Do().Raw()
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, result)
+	return
+}
+
+func (f *flowdeployments) Delete(name string, opts *api.DeleteOptions) error {
+	return f.rc.Delete().
+		Namespace(f.namespace).
+		Resource("deployments").
+		Name(name).
+		Body(opts).
+		Do().
+		Error()
+}
+
+func (f *flowdeployments) Get(name string) (result *FlowDeployment, err error) {
+	err = f.rc.Get().
+		Namespace(f.namespace).
+		Resource("deployments").
+		Name(name).
+		Do().Into(result)
+
+	return
+}
+
+func (f *FlowDeployment) UnmarshalJSON(data []byte) error {
+	type FlowDeploymentCopy FlowDeployment
+	tmp := FlowDeploymentCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := FlowDeployment(tmp)
+	*f = tmp2
+	return nil
+}
+
+func (fl *FlowDeploymentList) UnmarshalJSON(data []byte) error {
+	type FlowDeploymentListCopy FlowDeploymentList
+	tmp := FlowDeploymentListCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := FlowDeploymentList(tmp)
+	*fl = tmp2
+	return nil
+}
+
+func (f *FlowDeployment) ReplicaName() string {
+	return f.Name[1+strings.LastIndex(f.Name, "-"):]
 }

--- a/pkg/copier/copier.go
+++ b/pkg/copier/copier.go
@@ -1,0 +1,159 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Based on the work of Joel Scoble:
+// https://github.com/mohae/deepcopy/blob/master/deepcopy.go
+// (The MIT License)
+
+package copier
+
+import (
+	"reflect"
+	"regexp"
+	"time"
+)
+
+var varsRe, _ = regexp.Compile("\\$\\w+\\b")
+
+// Copy creates a deep copy of whatever is passed to it and returns the copy
+// in an interface{}.  The returned value will need to be asserted to the
+// correct type.
+func Copy(src interface{}) interface{} {
+	return CopyWithReplacements(src, func(p string) string {
+		return p
+	})
+}
+
+// CopyWithReplacements does deep copy of the object and performs string substitution for the string fields
+func CopyWithReplacements(src interface{}, replacementsFunc func(string) string, replaceIn ...string) interface{} {
+	if src == nil {
+		return nil
+	}
+
+	// Make the interface a reflect.Value
+	original := reflect.ValueOf(src)
+
+	// Make a copy of the same type as the original.
+	cpy := reflect.New(original.Type()).Elem()
+
+	// Recursively copy the original.
+	copyRecursive(original, cpy, replacementsFunc, "", replaceIn...)
+
+	// Return the copy as an interface.
+	return cpy.Interface()
+}
+
+// copyRecursive does the actual copying of the interface. It currently has
+// limited support for what it can handle. Add as needed.
+func copyRecursive(original, cpy reflect.Value, replacementsFunc func(string) string, path string, replaceIn ...string) {
+	// handle according to original's Kind
+	switch original.Kind() {
+	case reflect.Ptr:
+		// Get the actual value being pointed to.
+		originalValue := original.Elem()
+
+		// if  it isn't valid, return.
+		if !originalValue.IsValid() {
+			return
+		}
+		cpy.Set(reflect.New(originalValue.Type()))
+		copyRecursive(originalValue, cpy.Elem(), replacementsFunc, path, replaceIn...)
+
+	case reflect.Interface:
+		// If this is a nil, don't do anything
+		if original.IsNil() {
+			return
+		}
+		// Get the value for the interface, not the pointer.
+		originalValue := original.Elem()
+
+		// Get the value by calling Elem().
+		copyValue := reflect.New(originalValue.Type()).Elem()
+		copyRecursive(originalValue, copyValue, replacementsFunc, path, replaceIn...)
+		cpy.Set(copyValue)
+
+	case reflect.Struct:
+		t, ok := original.Interface().(time.Time)
+		if ok {
+			cpy.Set(reflect.ValueOf(t))
+			return
+		}
+		// Go through each field of the struct and copy it.
+		for i := 0; i < original.NumField(); i++ {
+			// The Type's StructField for a given field is checked to see if StructField.PkgPath
+			// is set to determine if the field is exported or not because CanSet() returns false
+			// for settable fields.  I'm not sure why.  -mohae
+			if original.Type().Field(i).PkgPath != "" {
+				continue
+			}
+			name := original.Type().Field(i).Name
+			var newPath string
+			if path == "" {
+				newPath = name
+			} else {
+				newPath = path + "." + name
+			}
+			found := false
+			for _, r := range replaceIn {
+				if r == newPath || r == "*" {
+					found = true
+					break
+				}
+			}
+			if found {
+				copyRecursive(original.Field(i), cpy.Field(i), replacementsFunc, newPath, "*")
+			} else {
+				copyRecursive(original.Field(i), cpy.Field(i), replacementsFunc, newPath, replaceIn...)
+			}
+		}
+
+	case reflect.Slice:
+		if original.IsNil() {
+			return
+		}
+		// Make a new slice and copy each element.
+		cpy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
+		for i := 0; i < original.Len(); i++ {
+			copyRecursive(original.Index(i), cpy.Index(i), replacementsFunc, path, replaceIn...)
+		}
+
+	case reflect.Map:
+		if original.IsNil() {
+			return
+		}
+		cpy.Set(reflect.MakeMap(original.Type()))
+		for _, key := range original.MapKeys() {
+			originalValue := original.MapIndex(key)
+			copyValue := reflect.New(originalValue.Type()).Elem()
+			copyRecursive(originalValue, copyValue, replacementsFunc, path, replaceIn...)
+			cpy.SetMapIndex(key, copyValue)
+		}
+	case reflect.String:
+		for _, r := range replaceIn {
+			if path == r || r == "*" {
+				cpy.Set(reflect.ValueOf(EvaluateString(original.String(), replacementsFunc)).Convert(original.Type()))
+				return
+			}
+		}
+		cpy.Set(original)
+	default:
+		cpy.Set(original)
+	}
+}
+
+func EvaluateString(template string, replacementsFunc func(string) string) string {
+	return varsRe.ReplaceAllStringFunc(template, func(p string) string {
+		return replacementsFunc(p[1:])
+	})
+}

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -75,8 +75,15 @@ type GraphContext interface {
 	Scheduler() Scheduler
 	Args() map[string]string
 	Graph() DependencyGraph
+	GraphOptions() DependencyGraphOptions
+}
+
+type DependencyGraphOptions struct {
+	FlowName     string
+	Args         map[string]string
+	ExportedOnly bool
 }
 
 type Scheduler interface {
-	BuildDependencyGraph(flowName string, args map[string]string) (DependencyGraph, error)
+	BuildDependencyGraph(options DependencyGraphOptions) (DependencyGraph, error)
 }

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -73,15 +73,15 @@ type DependencyGraph interface {
 
 type GraphContext interface {
 	Scheduler() Scheduler
-	Args() map[string]string
+	GetArg(string) string
 	Graph() DependencyGraph
-	GraphOptions() DependencyGraphOptions
 }
 
 type DependencyGraphOptions struct {
-	FlowName     string
-	Args         map[string]string
-	ExportedOnly bool
+	FlowName            string
+	Args                map[string]string
+	ExportedOnly        bool
+	AllowUndeclaredArgs bool
 }
 
 type Scheduler interface {

--- a/pkg/mocks/client.go
+++ b/pkg/mocks/client.go
@@ -30,12 +30,14 @@ func newClient(apiVersions *unversioned.APIGroupList, objects ...runtime.Object)
 	fakeClientset := fake.NewSimpleClientset(objects...)
 	apps := &alphafake.FakeApps{&fakeClientset.Fake}
 	deps := &FakeDeps{fake: &fakeClientset.Fake, ns: ns}
+	flowDeployments := &FakeFlowDeployments{fake: &fakeClientset.Fake, ns: ns}
 	resDefs := &FakeResDef{fake: &fakeClientset.Fake, ns: ns}
 	return client.NewClient(
 		fakeClientset,
 		apps,
 		deps,
 		resDefs,
+		flowDeployments,
 		ns,
 		apiVersions)
 }

--- a/pkg/mocks/fake_dependencies.go
+++ b/pkg/mocks/fake_dependencies.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// FakeFlows implements DependenciesInterface
+// FakeDeps implements DependenciesInterface
 type FakeDeps struct {
 	fake *testing.Fake
 	ns   string

--- a/pkg/mocks/fake_flowsdeployments.go
+++ b/pkg/mocks/fake_flowsdeployments.go
@@ -1,0 +1,124 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/labels"
+	"k8s.io/client-go/pkg/types"
+	"k8s.io/client-go/testing"
+)
+
+// FakeFlowDeployments implements FlowDeploymentsInterface
+type FakeFlowDeployments struct {
+	fake *testing.Fake
+	ns   string
+}
+
+var flowDeploymentResource = unversioned.GroupVersionResource{
+	Group:    "appcontroller.k8s",
+	Version:  "v1alpha1",
+	Resource: "deployments",
+}
+
+func (fd *FakeFlowDeployments) Create(flowDeployment *client.FlowDeployment) (result *client.FlowDeployment, err error) {
+	obj, err := fd.fake.
+		Invokes(testing.NewCreateAction(flowDeploymentResource, fd.ns, flowDeployment), &client.FlowDeployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	res := obj.(*client.FlowDeployment)
+	res.SetCreationTimestamp(unversioned.Time{time.Now()})
+	uuid, _ := newUUID()
+	res.SetUID(types.UID(uuid))
+
+	return res, err
+}
+
+func (fd *FakeFlowDeployments) Update(flowDeployment *client.FlowDeployment) (result *client.FlowDeployment, err error) {
+	obj, err := fd.fake.
+		Invokes(testing.NewUpdateAction(flowDeploymentResource, fd.ns, flowDeployment), &client.FlowDeployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*client.FlowDeployment), err
+}
+
+func (fd *FakeFlowDeployments) Delete(name string, options *api.DeleteOptions) error {
+	_, err := fd.fake.
+		Invokes(testing.NewDeleteAction(flowDeploymentResource, fd.ns, name), &client.FlowDeployment{})
+
+	return err
+}
+
+func (fd *FakeFlowDeployments) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(flowDeploymentResource, fd.ns, listOptions)
+
+	_, err := fd.fake.Invokes(action, &client.FlowDeployment{})
+	return err
+}
+
+func (fd *FakeFlowDeployments) Get(name string) (result *client.FlowDeployment, err error) {
+	obj, err := fd.fake.
+		Invokes(testing.NewGetAction(flowDeploymentResource, fd.ns, name), &client.FlowDeployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*client.FlowDeployment), err
+}
+
+func (fd *FakeFlowDeployments) List(opts api.ListOptions) (result *client.FlowDeploymentList, err error) {
+	obj, err := fd.fake.
+		Invokes(testing.NewListAction(flowDeploymentResource, fd.ns, opts), &client.FlowDeploymentList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &client.FlowDeploymentList{}
+	for _, item := range obj.(*client.FlowDeploymentList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+func newUUID() (string, error) {
+	uuid := make([]byte, 16)
+	n, err := io.ReadFull(rand.Reader, uuid)
+	if n != len(uuid) || err != nil {
+		return "", err
+	}
+	// variant bits; see section 4.1.1
+	uuid[8] = uuid[8]&^0xc0 | 0x80
+	// version 4 (pseudo-random); see section 4.1.3
+	uuid[6] = uuid[6]&^0xf0 | 0x40
+	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
+}

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"github.com/Mirantis/k8s-AppController/pkg/copier"
 	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 
 	"k8s.io/client-go/pkg/api/v1"
@@ -208,4 +209,15 @@ func GetStringMeta(r interfaces.BaseResource, paramName string, defaultValue str
 	}
 
 	return string(strVal)
+}
+
+// Substitutes flow arguments into resource structure. Returns modified copy of the resource
+func parametrizeResource(resource interface{}, context interfaces.GraphContext, replaceIn ...string) interface{} {
+	return copier.CopyWithReplacements(resource, func(p string) string {
+		value := context.GetArg(p)
+		if value == "" {
+			return "$" + p
+		}
+		return value
+	}, append(replaceIn, "ObjectMeta")...)
 }

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mirantis/k8s-AppController/pkg/copier"
 	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 
+	"k8s.io/client-go/pkg/api/meta"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/labels"
 )
@@ -220,4 +221,12 @@ func parametrizeResource(resource interface{}, context interfaces.GraphContext, 
 		}
 		return value
 	}, append(replaceIn, "ObjectMeta")...)
+}
+
+func getObjectName(resource meta.Object) string {
+	name := resource.GetName()
+	if name != "" {
+		return name
+	}
+	return resource.GetGenerateName()
 }

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -39,12 +39,12 @@ type ExistingConfigMap struct {
 
 type configMapTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a configmap
+// ShortName returns wrapped resource name if it was a configmap
 func (configMapTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.ConfigMap == nil {
 		return ""
 	}
-	return definition.ConfigMap.Name
+	return getObjectName(definition.ConfigMap)
 }
 
 // k8s resource kind that this fabric supports
@@ -67,7 +67,7 @@ func configMapKey(name string) string {
 }
 
 func (c ConfigMap) Key() string {
-	return configMapKey(c.ConfigMap.Name)
+	return configMapKey(getObjectName(c.ConfigMap))
 }
 
 func configMapStatus(c corev1.ConfigMapInterface, name string) (interfaces.ResourceStatus, error) {
@@ -84,7 +84,7 @@ func (c ConfigMap) Status(meta map[string]string) (interfaces.ResourceStatus, er
 	return configMapStatus(c.Client, c.ConfigMap.Name)
 }
 
-func (c ConfigMap) Create() error {
+func (c *ConfigMap) Create() error {
 	if err := checkExistence(c); err != nil {
 		log.Println("Creating", c.Key())
 		c.ConfigMap, err = c.Client.Create(c.ConfigMap)
@@ -98,7 +98,7 @@ func (c ConfigMap) Delete() error {
 }
 
 func NewConfigMap(c *v1.ConfigMap, client corev1.ConfigMapInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ConfigMap{Base: Base{meta}, ConfigMap: c, Client: client}}
+	return report.SimpleReporter{BaseResource: &ConfigMap{Base: Base{meta}, ConfigMap: c, Client: client}}
 }
 
 func NewExistingConfigMap(name string, client corev1.ConfigMapInterface) interfaces.Resource {

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -54,7 +54,7 @@ func (configMapTemplateFactory) Kind() string {
 
 // New returns a new object wrapped as Resource
 func (configMapTemplateFactory) New(def client.ResourceDefinition, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewConfigMap(def.ConfigMap, ci.ConfigMaps(), def.Meta)
+	return NewConfigMap(parametrizeResource(def.ConfigMap, gc).(*v1.ConfigMap), ci.ConfigMaps(), def.Meta)
 }
 
 // NewExisting returns a new object based on existing one wrapped as Resource

--- a/pkg/resources/daemonset.go
+++ b/pkg/resources/daemonset.go
@@ -35,12 +35,12 @@ type DaemonSet struct {
 
 type daemonSetTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a daemonset
+// ShortName returns wrapped resource name if it was a daemonset
 func (daemonSetTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.DaemonSet == nil {
 		return ""
 	}
-	return definition.DaemonSet.Name
+	return getObjectName(definition.DaemonSet)
 }
 
 // k8s resource kind that this fabric supports
@@ -78,7 +78,7 @@ func daemonSetStatus(d v1beta1.DaemonSetInterface, name string) (interfaces.Reso
 
 // Key return DaemonSet key
 func (d DaemonSet) Key() string {
-	return daemonSetKey(d.DaemonSet.Name)
+	return daemonSetKey(getObjectName(d.DaemonSet))
 }
 
 // Status returns DaemonSet status. interfaces.ResourceReady means that its dependencies can be created
@@ -87,7 +87,7 @@ func (d DaemonSet) Status(meta map[string]string) (interfaces.ResourceStatus, er
 }
 
 // Create looks for DaemonSet in K8s and creates it if not present
-func (d DaemonSet) Create() error {
+func (d *DaemonSet) Create() error {
 	if err := checkExistence(d); err != nil {
 		log.Println("Creating", d.Key())
 		d.DaemonSet, err = d.Client.Create(d.DaemonSet)
@@ -103,7 +103,7 @@ func (d DaemonSet) Delete() error {
 
 // NewDaemonSet is a constructor
 func NewDaemonSet(daemonset *extbeta1.DaemonSet, client v1beta1.DaemonSetInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: DaemonSet{Base: Base{meta}, DaemonSet: daemonset, Client: client}}
+	return report.SimpleReporter{BaseResource: &DaemonSet{Base: Base{meta}, DaemonSet: daemonset, Client: client}}
 }
 
 // ExistingDaemonSet is a wrapper for K8s DaemonSet object which is deployed on a cluster before AppController

--- a/pkg/resources/daemonset.go
+++ b/pkg/resources/daemonset.go
@@ -50,7 +50,10 @@ func (daemonSetTemplateFactory) Kind() string {
 
 // New returns new DaemonSet based on resource definition
 func (d daemonSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewDaemonSet(def.DaemonSet, c.DaemonSets(), def.Meta)
+	newDaemonSet := parametrizeResource(def.DaemonSet, gc,
+		"Spec.Template.Spec.Containers.Env",
+		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.DaemonSet)
+	return NewDaemonSet(newDaemonSet, c.DaemonSets(), def.Meta)
 }
 
 // NewExisting returns new ExistingDaemonSet based on resource definition

--- a/pkg/resources/deployment.go
+++ b/pkg/resources/deployment.go
@@ -50,7 +50,10 @@ func (deploymentTemplateFactory) Kind() string {
 
 // New returns new Deployment based on resource definition
 func (deploymentTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewDeployment(def.Deployment, c.Deployments(), def.Meta)
+	newDeployment := parametrizeResource(def.Deployment, gc,
+		"Spec.Template.Spec.Containers.Env",
+		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.Deployment)
+	return NewDeployment(newDeployment, c.Deployments(), def.Meta)
 }
 
 // NewExisting returns new ExistingDeployment based on resource definition

--- a/pkg/resources/deployment.go
+++ b/pkg/resources/deployment.go
@@ -35,12 +35,12 @@ type Deployment struct {
 
 type deploymentTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a deployment
+// ShortName returns wrapped resource name if it was a deployment
 func (deploymentTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.Deployment == nil {
 		return ""
 	}
-	return definition.Deployment.Name
+	return getObjectName(definition.Deployment)
 }
 
 // k8s resource kind that this fabric supports
@@ -79,7 +79,7 @@ func deploymentStatus(d v1beta1.DeploymentInterface, name string) (interfaces.Re
 
 // Key return Deployment key
 func (d Deployment) Key() string {
-	return deploymentKey(d.Deployment.Name)
+	return deploymentKey(getObjectName(d.Deployment))
 }
 
 // Status returns Deployment status. interfaces.ResourceReady means that its dependencies can be created
@@ -88,7 +88,7 @@ func (d Deployment) Status(meta map[string]string) (interfaces.ResourceStatus, e
 }
 
 // Create looks for Deployment in K8s and creates it if not present
-func (d Deployment) Create() error {
+func (d *Deployment) Create() error {
 	log.Println("Looking for deployment", d.Deployment.Name)
 	status, err := d.Status(nil)
 
@@ -108,7 +108,7 @@ func (d Deployment) Delete() error {
 
 // NewDeployment is a constructor
 func NewDeployment(deployment *extbeta1.Deployment, client v1beta1.DeploymentInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: Deployment{Base: Base{meta}, Deployment: deployment, Client: client}}
+	return report.SimpleReporter{BaseResource: &Deployment{Base: Base{meta}, Deployment: deployment, Client: client}}
 }
 
 // ExistingDeployment is a wrapper for K8s Deployment object which is deployed on a cluster before AppController

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -69,7 +69,10 @@ func (f Flow) Key() string {
 
 // Triggers the flow deployment like it was the resource creation
 func (f *Flow) Create() error {
-	graph, err := f.scheduler.BuildDependencyGraph(f.flow.Name, map[string]string{})
+	options := interfaces.DependencyGraphOptions{
+		FlowName: f.flow.Name,
+	}
+	graph, err := f.scheduler.BuildDependencyGraph(options)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -16,7 +16,9 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"log"
+	"sync/atomic"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
 	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
@@ -25,12 +27,16 @@ import (
 
 type Flow struct {
 	Base
-	flow      *client.Flow
-	scheduler interfaces.Scheduler
-	status    interfaces.ResourceStatus
+	flow          *client.Flow
+	context       interfaces.GraphContext
+	status        interfaces.ResourceStatus
+	generatedName string
+	originalName  string
 }
 
 type flowTemplateFactory struct{}
+
+var counter uint32
 
 // Returns wrapped resource name if it was a flow
 func (flowTemplateFactory) ShortName(definition client.ResourceDefinition) string {
@@ -47,12 +53,16 @@ func (flowTemplateFactory) Kind() string {
 
 // New returns a new object wrapped as Resource
 func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
+	newFlow := parametrizeResource(def.Flow, gc).(*client.Flow)
+
 	return report.SimpleReporter{
 		BaseResource: &Flow{
-			Base:      Base{def.Meta},
-			flow:      def.Flow,
-			scheduler: gc.Scheduler(),
-			status:    interfaces.ResourceNotReady,
+			Base:          Base{def.Meta},
+			flow:          newFlow,
+			context:       gc,
+			status:        interfaces.ResourceNotReady,
+			generatedName: fmt.Sprintf("%s-%v", newFlow.Name, atomic.AddUint32(&counter, 1)),
+			originalName:  def.Flow.Name,
 		}}
 }
 
@@ -64,15 +74,23 @@ func (flowTemplateFactory) NewExisting(name string, c client.Interface, gc inter
 
 // Identifier of the object
 func (f Flow) Key() string {
-	return "flow/" + f.flow.Name
+	return "flow/" + f.generatedName
 }
 
 // Triggers the flow deployment like it was the resource creation
 func (f *Flow) Create() error {
-	options := interfaces.DependencyGraphOptions{
-		FlowName: f.flow.Name,
+	args := map[string]string{}
+	for arg := range f.flow.Parameters {
+		val := f.context.GetArg(arg)
+		if val != "" {
+			args[arg] = val
+		}
 	}
-	graph, err := f.scheduler.BuildDependencyGraph(options)
+	options := interfaces.DependencyGraphOptions{
+		FlowName: f.originalName,
+		Args:     args,
+	}
+	graph, err := f.context.Scheduler().BuildDependencyGraph(options)
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -38,12 +38,12 @@ type flowTemplateFactory struct{}
 
 var counter uint32
 
-// Returns wrapped resource name if it was a flow
+// ShortName returns wrapped resource name if it was a flow
 func (flowTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.Flow == nil {
 		return ""
 	}
-	return definition.Flow.Name
+	return getObjectName(definition.Flow)
 }
 
 // k8s resource kind that this fabric supports
@@ -61,14 +61,14 @@ func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface
 			flow:          newFlow,
 			context:       gc,
 			status:        interfaces.ResourceNotReady,
-			generatedName: fmt.Sprintf("%s-%v", newFlow.Name, atomic.AddUint32(&counter, 1)),
-			originalName:  def.Flow.Name,
+			generatedName: fmt.Sprintf("%s-%v", getObjectName(newFlow), atomic.AddUint32(&counter, 1)),
+			originalName:  getObjectName(def.Flow),
 		}}
 }
 
 // NewExisting returns a new object based on existing one wrapped as Resource
 func (flowTemplateFactory) NewExisting(name string, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	log.Fatal("Cannot depend on flow that has no resource definition")
+	log.Fatal("cannot depend on flow that has no resource definition")
 	return nil
 }
 

--- a/pkg/resources/job.go
+++ b/pkg/resources/job.go
@@ -52,7 +52,10 @@ func (jobTemplateFactory) Kind() string {
 
 // New returns new Job on resource definition
 func (jobTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewJob(def.Job, c.Jobs(), def.Meta)
+	newJob := parametrizeResource(def.Job, gc,
+		"Spec.Template.Spec.Containers.Env",
+		"Spec.Template.Spec.InitContainers.Env").(*v1.Job)
+	return NewJob(newJob, c.Jobs(), def.Meta)
 }
 
 // NewExisting returns new ExistingJob based on resource definition

--- a/pkg/resources/job.go
+++ b/pkg/resources/job.go
@@ -37,12 +37,12 @@ func jobKey(name string) string {
 
 type jobTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a job
+// ShortName returns wrapped resource name if it was a job
 func (jobTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.Job == nil {
 		return ""
 	}
-	return definition.Job.Name
+	return getObjectName(definition.Job)
 }
 
 // k8s resource kind that this fabric supports
@@ -80,7 +80,7 @@ func jobStatus(j batchv1.JobInterface, name string) (interfaces.ResourceStatus, 
 
 // Key returns job name
 func (j Job) Key() string {
-	return jobKey(j.Job.Name)
+	return jobKey(getObjectName(j.Job))
 }
 
 // Status returns job status
@@ -89,7 +89,7 @@ func (j Job) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 }
 
 // Create creates k8s job object
-func (j Job) Create() error {
+func (j *Job) Create() error {
 	if err := checkExistence(j); err != nil {
 		log.Println("Creating", j.Key())
 		j.Job, err = j.Client.Create(j.Job)
@@ -104,7 +104,7 @@ func (j Job) Delete() error {
 }
 
 func NewJob(job *v1.Job, client batchv1.JobInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: Job{Base: Base{meta}, Job: job, Client: client}}
+	return report.SimpleReporter{BaseResource: &Job{Base: Base{meta}, Job: job, Client: client}}
 }
 
 type ExistingJob struct {

--- a/pkg/resources/persistentvolumeclaim.go
+++ b/pkg/resources/persistentvolumeclaim.go
@@ -48,7 +48,8 @@ func (persistentVolumeClaimTemplateFactory) Kind() string {
 
 // New returns new PersistentVolumeClaim based on resource definition
 func (persistentVolumeClaimTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewPersistentVolumeClaim(def.PersistentVolumeClaim, c.PersistentVolumeClaims(), def.Meta)
+	return NewPersistentVolumeClaim(parametrizeResource(def.PersistentVolumeClaim, gc).(*v1.PersistentVolumeClaim),
+		c.PersistentVolumeClaims(), def.Meta)
 }
 
 // NewExisting returns new ExistingPersistentVolumeClaim based on resource definition

--- a/pkg/resources/persistentvolumeclaim.go
+++ b/pkg/resources/persistentvolumeclaim.go
@@ -33,12 +33,12 @@ type PersistentVolumeClaim struct {
 
 type persistentVolumeClaimTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a persistentvolumeclaim
+// ShortName returns wrapped resource name if it was a persistentvolumeclaim
 func (persistentVolumeClaimTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.PersistentVolumeClaim == nil {
 		return ""
 	}
-	return definition.PersistentVolumeClaim.Name
+	return getObjectName(definition.PersistentVolumeClaim)
 }
 
 // k8s resource kind that this fabric supports
@@ -62,7 +62,7 @@ func persistentVolumeClaimKey(name string) string {
 }
 
 func (p PersistentVolumeClaim) Key() string {
-	return persistentVolumeClaimKey(p.PersistentVolumeClaim.Name)
+	return persistentVolumeClaimKey(getObjectName(p.PersistentVolumeClaim))
 }
 
 func persistentVolumeClaimStatus(p corev1.PersistentVolumeClaimInterface, name string) (interfaces.ResourceStatus, error) {
@@ -78,7 +78,7 @@ func persistentVolumeClaimStatus(p corev1.PersistentVolumeClaimInterface, name s
 	return interfaces.ResourceNotReady, nil
 }
 
-func (p PersistentVolumeClaim) Create() error {
+func (p *PersistentVolumeClaim) Create() error {
 	if err := checkExistence(p); err != nil {
 		log.Println("Creating", p.Key())
 		p.PersistentVolumeClaim, err = p.Client.Create(p.PersistentVolumeClaim)
@@ -98,7 +98,7 @@ func (p PersistentVolumeClaim) Status(meta map[string]string) (interfaces.Resour
 }
 
 func NewPersistentVolumeClaim(persistentVolumeClaim *v1.PersistentVolumeClaim, client corev1.PersistentVolumeClaimInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: PersistentVolumeClaim{Base: Base{meta}, PersistentVolumeClaim: persistentVolumeClaim, Client: client}}
+	return report.SimpleReporter{BaseResource: &PersistentVolumeClaim{Base: Base{meta}, PersistentVolumeClaim: persistentVolumeClaim, Client: client}}
 }
 
 type ExistingPersistentVolumeClaim struct {

--- a/pkg/resources/petset.go
+++ b/pkg/resources/petset.go
@@ -49,7 +49,10 @@ func (petSetTemplateFactory) Kind() string {
 
 // New returns new PetSet based on resource definition
 func (petSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewPetSet(def.PetSet, c.PetSets(), c, def.Meta)
+	newPetSet := parametrizeResource(def.PetSet, gc,
+		"Spec.Template.Spec.Containers.Env",
+		"Spec.Template.Spec.InitContainers.Env").(*appsalpha1.PetSet)
+	return NewPetSet(newPetSet, c.PetSets(), c, def.Meta)
 }
 
 // NewExisting returns new ExistingPetSet based on resource definition

--- a/pkg/resources/petset.go
+++ b/pkg/resources/petset.go
@@ -34,12 +34,12 @@ type PetSet struct {
 
 type petSetTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a petset
+// ShortName returns wrapped resource name if it was a petset
 func (petSetTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.PetSet == nil {
 		return ""
 	}
-	return definition.PetSet.Name
+	return getObjectName(definition.PetSet)
 }
 
 // k8s resource kind that this fabric supports
@@ -75,14 +75,14 @@ func petsetKey(name string) string {
 
 // Key returns PetSet name
 func (p PetSet) Key() string {
-	return petsetKey(p.PetSet.Name)
+	return petsetKey(getObjectName(p.PetSet))
 }
 
 // Create looks for a PetSet in Kubernetes cluster and creates it if it's not there
-func (p PetSet) Create() error {
+func (p *PetSet) Create() error {
 	if err := checkExistence(p); err != nil {
 		log.Println("Creating", p.Key())
-		_, err = p.Client.Create(p.PetSet)
+		p.PetSet, err = p.Client.Create(p.PetSet)
 		return err
 	}
 	return nil
@@ -100,7 +100,7 @@ func (p PetSet) Status(meta map[string]string) (interfaces.ResourceStatus, error
 
 // NewPetSet is a constructor
 func NewPetSet(petset *appsalpha1.PetSet, client v1alpha1.PetSetInterface, apiClient client.Interface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: PetSet{Base: Base{meta}, PetSet: petset, Client: client, APIClient: apiClient}}
+	return report.SimpleReporter{BaseResource: &PetSet{Base: Base{meta}, PetSet: petset, Client: client, APIClient: apiClient}}
 }
 
 // ExistingPetSet is a wrapper for K8s PetSet object which is meant to already be in a cluster bofer AppController execution

--- a/pkg/resources/pod.go
+++ b/pkg/resources/pod.go
@@ -48,7 +48,10 @@ func (podTemplateFactory) Kind() string {
 
 // New returns new Pod based on resource definition
 func (podTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewPod(def.Pod, c.Pods(), def.Meta)
+	newPod := parametrizeResource(def.Pod, gc,
+		"Spec.Containers.Env",
+		"Spec.InitContainers.Env").(*v1.Pod)
+	return NewPod(newPod, c.Pods(), def.Meta)
 }
 
 // NewExisting returns new ExistingPod based on resource definition

--- a/pkg/resources/pod.go
+++ b/pkg/resources/pod.go
@@ -33,12 +33,12 @@ type Pod struct {
 
 type podTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a pod
+// ShortName returns wrapped resource name if it was a pod
 func (podTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.Pod == nil {
 		return ""
 	}
-	return definition.Pod.Name
+	return getObjectName(definition.Pod)
 }
 
 // k8s resource kind that this fabric supports
@@ -64,7 +64,7 @@ func podKey(name string) string {
 }
 
 func (p Pod) Key() string {
-	return podKey(p.Pod.Name)
+	return podKey(getObjectName(p.Pod))
 }
 
 func podStatus(p corev1.PodInterface, name string) (interfaces.ResourceStatus, error) {
@@ -94,7 +94,7 @@ func isReady(pod *v1.Pod) bool {
 	return false
 }
 
-func (p Pod) Create() error {
+func (p *Pod) Create() error {
 	if err := checkExistence(p); err != nil {
 		log.Println("Creating", p.Key())
 		p.Pod, err = p.Client.Create(p.Pod)
@@ -120,7 +120,7 @@ func (p Pod) NameMatches(def client.ResourceDefinition, name string) bool {
 }
 
 func NewPod(pod *v1.Pod, client corev1.PodInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: Pod{Base: Base{meta}, Pod: pod, Client: client}}
+	return report.SimpleReporter{BaseResource: &Pod{Base: Base{meta}, Pod: pod, Client: client}}
 }
 
 type ExistingPod struct {

--- a/pkg/resources/replicaset.go
+++ b/pkg/resources/replicaset.go
@@ -51,7 +51,10 @@ func (replicaSetTemplateFactory) Kind() string {
 
 // New returns new ReplicaSet based on resource definition
 func (replicaSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewReplicaSet(def.ReplicaSet, c.ReplicaSets(), def.Meta)
+	newReplicaSet := parametrizeResource(def.ReplicaSet, gc,
+		"Spec.Template.Spec.Containers.Env",
+		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.ReplicaSet)
+	return NewReplicaSet(newReplicaSet, c.ReplicaSets(), def.Meta)
 }
 
 // NewExisting returns new ExistingReplicaSet based on resource definition

--- a/pkg/resources/replicaset.go
+++ b/pkg/resources/replicaset.go
@@ -36,12 +36,12 @@ type ReplicaSet struct {
 
 type replicaSetTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a replicaset
+// ShortName returns wrapped resource name if it was a replicaset
 func (replicaSetTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.ReplicaSet == nil {
 		return ""
 	}
-	return definition.ReplicaSet.Name
+	return getObjectName(definition.ReplicaSet)
 }
 
 // k8s resource kind that this fabric supports
@@ -120,10 +120,10 @@ func replicaSetKey(name string) string {
 }
 
 func (r ReplicaSet) Key() string {
-	return replicaSetKey(r.ReplicaSet.Name)
+	return replicaSetKey(getObjectName(r.ReplicaSet))
 }
 
-func (r ReplicaSet) Create() error {
+func (r *ReplicaSet) Create() error {
 	if err := checkExistence(r); err != nil {
 		log.Println("Creating", r.Key())
 		r.ReplicaSet, err = r.Client.Create(r.ReplicaSet)
@@ -153,8 +153,8 @@ func (r ReplicaSet) StatusIsCacheable(meta map[string]string) bool {
 	return !ok
 }
 
-func NewReplicaSet(replicaSet *extbeta1.ReplicaSet, client v1beta1.ReplicaSetInterface, meta map[string]interface{}) ReplicaSet {
-	return ReplicaSet{Base: Base{meta}, ReplicaSet: replicaSet, Client: client}
+func NewReplicaSet(replicaSet *extbeta1.ReplicaSet, client v1beta1.ReplicaSetInterface, meta map[string]interface{}) *ReplicaSet {
+	return &ReplicaSet{Base: Base{meta}, ReplicaSet: replicaSet, Client: client}
 }
 
 type ExistingReplicaSet struct {

--- a/pkg/resources/secrets.go
+++ b/pkg/resources/secrets.go
@@ -53,7 +53,7 @@ func (secretTemplateFactory) Kind() string {
 }
 
 func (secretTemplateFactory) New(def client.ResourceDefinition, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewSecret(def.Secret, ci.Secrets(), def.Meta)
+	return NewSecret(parametrizeResource(def.Secret, gc).(*v1.Secret), ci.Secrets(), def.Meta)
 }
 
 func (secretTemplateFactory) NewExisting(name string, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {

--- a/pkg/resources/secrets.go
+++ b/pkg/resources/secrets.go
@@ -39,12 +39,12 @@ type ExistingSecret struct {
 
 type secretTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a secret
+// ShortName returns wrapped resource name if it was a secret
 func (secretTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.Secret == nil {
 		return ""
 	}
-	return definition.Secret.Name
+	return getObjectName(definition.Secret)
 }
 
 // k8s resource kind that this fabric supports
@@ -65,7 +65,7 @@ func secretKey(name string) string {
 }
 
 func (s Secret) Key() string {
-	return secretKey(s.Secret.Name)
+	return secretKey(getObjectName(s.Secret))
 }
 
 func (s ExistingSecret) Key() string {
@@ -86,7 +86,7 @@ func (s Secret) Status(meta map[string]string) (interfaces.ResourceStatus, error
 	return secretStatus(s.Client, s.Secret.Name)
 }
 
-func (s Secret) Create() error {
+func (s *Secret) Create() error {
 	if err := checkExistence(s); err != nil {
 		log.Println("Creating", s.Key())
 		s.Secret, err = s.Client.Create(s.Secret)
@@ -100,7 +100,7 @@ func (s Secret) Delete() error {
 }
 
 func NewSecret(s *v1.Secret, client corev1.SecretInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: Secret{Base: Base{meta}, Secret: s, Client: client}}
+	return report.SimpleReporter{BaseResource: &Secret{Base: Base{meta}, Secret: s, Client: client}}
 }
 
 func NewExistingSecret(name string, client corev1.SecretInterface) interfaces.Resource {

--- a/pkg/resources/service.go
+++ b/pkg/resources/service.go
@@ -53,7 +53,7 @@ func (serviceTemplateFactory) Kind() string {
 
 // New returns new Service based on resource definition
 func (serviceTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewService(def.Service, c.Services(), c, def.Meta)
+	return NewService(parametrizeResource(def.Service, gc).(*v1.Service), c.Services(), c, def.Meta)
 }
 
 // NewExisting returns new ExistingService based on resource definition

--- a/pkg/resources/service.go
+++ b/pkg/resources/service.go
@@ -38,12 +38,12 @@ type Service struct {
 
 type serviceTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a service
+// ShortName returns wrapped resource name if it was a service
 func (serviceTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.Service == nil {
 		return ""
 	}
-	return definition.Service.Name
+	return getObjectName(definition.Service)
 }
 
 // k8s resource kind that this fabric supports
@@ -132,10 +132,10 @@ func serviceKey(name string) string {
 }
 
 func (s Service) Key() string {
-	return serviceKey(s.Service.Name)
+	return serviceKey(getObjectName(s.Service))
 }
 
-func (s Service) Create() error {
+func (s *Service) Create() error {
 	if err := checkExistence(s); err != nil {
 		log.Println("Creating", s.Key())
 		s.Service, err = s.Client.Create(s.Service)
@@ -156,7 +156,7 @@ func (s Service) Status(meta map[string]string) (interfaces.ResourceStatus, erro
 
 // NewService is Service constructor. Needs apiClient for service status checks
 func NewService(service *v1.Service, client corev1.ServiceInterface, apiClient client.Interface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: Service{Base: Base{meta}, Service: service, Client: client, APIClient: apiClient}}
+	return report.SimpleReporter{BaseResource: &Service{Base: Base{meta}, Service: service, Client: client, APIClient: apiClient}}
 }
 
 // StatusIsCacheable for service always returns false since the status must be

--- a/pkg/resources/serviceaccount.go
+++ b/pkg/resources/serviceaccount.go
@@ -54,7 +54,7 @@ func (serviceAccountTemplateFactory) Kind() string {
 
 // New returns a new object wrapped as Resource
 func (serviceAccountTemplateFactory) New(def client.ResourceDefinition, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewServiceAccount(def.ServiceAccount, ci.ServiceAccounts(), def.Meta)
+	return NewServiceAccount(parametrizeResource(def.ServiceAccount, gc).(*v1.ServiceAccount), ci.ServiceAccounts(), def.Meta)
 }
 
 // NewExisting returns a new object based on existing one wrapped as Resource

--- a/pkg/resources/serviceaccount.go
+++ b/pkg/resources/serviceaccount.go
@@ -39,12 +39,12 @@ type ExistingServiceAccount struct {
 
 type serviceAccountTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a serviceaccount
+// ShortName returns wrapped resource name if it was a serviceaccount
 func (serviceAccountTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.ServiceAccount == nil {
 		return ""
 	}
-	return definition.ServiceAccount.Name
+	return getObjectName(definition.ServiceAccount)
 }
 
 // k8s resource kind that this fabric supports
@@ -67,7 +67,7 @@ func serviceAccountKey(name string) string {
 }
 
 func (c ServiceAccount) Key() string {
-	return serviceAccountKey(c.ServiceAccount.Name)
+	return serviceAccountKey(getObjectName(c.ServiceAccount))
 }
 
 func serviceAccountStatus(c corev1.ServiceAccountInterface, name string) (interfaces.ResourceStatus, error) {
@@ -83,7 +83,7 @@ func (c ServiceAccount) Status(meta map[string]string) (interfaces.ResourceStatu
 	return serviceAccountStatus(c.Client, c.ServiceAccount.Name)
 }
 
-func (c ServiceAccount) Create() error {
+func (c *ServiceAccount) Create() error {
 	if err := checkExistence(c); err != nil {
 		log.Println("Creating", c.Key())
 		c.ServiceAccount, err = c.Client.Create(c.ServiceAccount)
@@ -97,7 +97,7 @@ func (c ServiceAccount) Delete() error {
 }
 
 func NewServiceAccount(c *v1.ServiceAccount, client corev1.ServiceAccountInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ServiceAccount{Base: Base{meta}, ServiceAccount: c, Client: client}}
+	return report.SimpleReporter{BaseResource: &ServiceAccount{Base: Base{meta}, ServiceAccount: c, Client: client}}
 }
 
 func NewExistingServiceAccount(name string, client corev1.ServiceAccountInterface) interfaces.Resource {

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -35,12 +35,12 @@ type StatefulSet struct {
 
 type statefulSetTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a statefulset
+// ShortName returns wrapped resource name if it was a statefulset
 func (statefulSetTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.StatefulSet == nil {
 		return ""
 	}
-	return definition.StatefulSet.Name
+	return getObjectName(definition.StatefulSet)
 }
 
 // k8s resource kind that this fabric supports
@@ -51,7 +51,7 @@ func (statefulSetTemplateFactory) Kind() string {
 // New returns new StatefulSet based on resource definition
 func (statefulSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	newStatefulSet := parametrizeResource(def.StatefulSet, gc,
-	"Spec.Template.Spec.Containers.Env",
+		"Spec.Template.Spec.Containers.Env",
 		"Spec.Template.Spec.InitContainers.Env").(*appsbeta1.StatefulSet)
 	return NewStatefulSet(newStatefulSet, c.StatefulSets(), c, def.Meta)
 }
@@ -76,14 +76,14 @@ func statefulsetKey(name string) string {
 
 // Key returns StatefulSet name
 func (p StatefulSet) Key() string {
-	return statefulsetKey(p.StatefulSet.Name)
+	return statefulsetKey(getObjectName(p.StatefulSet))
 }
 
 // Create looks for a StatefulSet in Kubernetes cluster and creates it if it's not there
-func (p StatefulSet) Create() error {
+func (p *StatefulSet) Create() error {
 	if err := checkExistence(p); err != nil {
 		log.Println("Creating", p.Key())
-		_, err = p.Client.Create(p.StatefulSet)
+		p.StatefulSet, err = p.Client.Create(p.StatefulSet)
 		return err
 	}
 	return nil
@@ -101,7 +101,7 @@ func (p StatefulSet) Status(meta map[string]string) (interfaces.ResourceStatus, 
 
 // NewStatefulSet is a constructor
 func NewStatefulSet(statefulset *appsbeta1.StatefulSet, client v1beta1.StatefulSetInterface, apiClient client.Interface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: StatefulSet{Base: Base{meta}, StatefulSet: statefulset, Client: client, APIClient: apiClient}}
+	return report.SimpleReporter{BaseResource: &StatefulSet{Base: Base{meta}, StatefulSet: statefulset, Client: client, APIClient: apiClient}}
 }
 
 // ExistingStatefulSet is a wrapper for K8s StatefulSet object which is meant to already be in a cluster bofer AppController execution

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -50,7 +50,10 @@ func (statefulSetTemplateFactory) Kind() string {
 
 // New returns new StatefulSet based on resource definition
 func (statefulSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewStatefulSet(def.StatefulSet, c.StatefulSets(), c, def.Meta)
+	newStatefulSet := parametrizeResource(def.StatefulSet, gc,
+	"Spec.Template.Spec.Containers.Env",
+		"Spec.Template.Spec.InitContainers.Env").(*appsbeta1.StatefulSet)
+	return NewStatefulSet(newStatefulSet, c.StatefulSets(), c, def.Meta)
 }
 
 // NewExisting returns new ExistingStatefulSet based on resource definition

--- a/pkg/scheduler/dependency_graph.go
+++ b/pkg/scheduler/dependency_graph.go
@@ -21,24 +21,27 @@ import (
 	"strings"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"github.com/Mirantis/k8s-AppController/pkg/copier"
 	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 	"github.com/Mirantis/k8s-AppController/pkg/resources"
 
 	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/unversioned"
 )
 
 // DependencyGraph is a full deployment depGraph as a mapping from job keys to
 // ScheduledResource pointers
 type DependencyGraph struct {
 	graph        map[string]*ScheduledResource
-	graphOptions interfaces.DependencyGraphOptions
 	scheduler    *Scheduler
+	graphOptions interfaces.DependencyGraphOptions
 }
 
 type GraphContext struct {
 	args      map[string]string
 	graph     *DependencyGraph
 	scheduler *Scheduler
+	flow      *client.Flow
 }
 
 // Returns the Scheduler that was used to create the dependency graph
@@ -47,8 +50,20 @@ func (gc GraphContext) Scheduler() interfaces.Scheduler {
 }
 
 // Returns argument values available in the current graph context
-func (gc GraphContext) Args() map[string]string {
-	return gc.args
+func (gc GraphContext) GetArg(name string) string {
+	val, ok := gc.args[name]
+	if ok {
+		return val
+	}
+	val, ok = gc.graph.graphOptions.Args[name]
+	if ok {
+		return val
+	}
+	fp, ok := gc.flow.Parameters[name]
+	if ok && fp.Default != nil {
+		return *fp.Default
+	}
+	return ""
 }
 
 // Returns the currently running dependency graph
@@ -56,19 +71,15 @@ func (gc GraphContext) Graph() interfaces.DependencyGraph {
 	return gc.graph
 }
 
-// Returns the currently running dependency graph
-func (gc GraphContext) GraphOptions() interfaces.DependencyGraphOptions {
-	return gc.graph.graphOptions
-}
-
 // newScheduledResourceFor returns new scheduled resource for given resource in init state
-func newScheduledResourceFor(r interfaces.Resource) *ScheduledResource {
+func newScheduledResourceFor(r interfaces.Resource, context *GraphContext) *ScheduledResource {
 	return &ScheduledResource{
 		Started:  false,
 		Ignored:  false,
 		Error:    nil,
 		Resource: r,
 		Meta:     map[string]map[string]string{},
+		Context:  context,
 	}
 }
 
@@ -149,11 +160,9 @@ func filterDependencies(dependencies map[string][]client.Dependency, parent stri
 }
 
 func canDependencyBelongToFlow(dep *client.Dependency, flow *client.Flow) bool {
-	if flow != nil {
-		for k, v := range flow.Construction {
-			if dep.Labels[k] != v {
-				return false
-			}
+	for k, v := range flow.Construction {
+		if dep.Labels[k] != v {
+			return false
 		}
 	}
 	return true
@@ -161,7 +170,7 @@ func canDependencyBelongToFlow(dep *client.Dependency, flow *client.Flow) bool {
 
 // newScheduledResource is a constructor for ScheduledResource
 func (sched Scheduler) newScheduledResource(kind, name string, resDefs map[string]client.ResourceDefinition,
-	gc GraphContext) (*ScheduledResource, error) {
+	gc *GraphContext) (*ScheduledResource, error) {
 
 	var r interfaces.Resource
 
@@ -175,19 +184,19 @@ func (sched Scheduler) newScheduledResource(kind, name string, resDefs map[strin
 		return nil, err
 	}
 
-	return newScheduledResourceFor(r), nil
+	return newScheduledResourceFor(r, gc), nil
 }
 
 func (sched Scheduler) newResource(kind, name string, resDefs map[string]client.ResourceDefinition,
-	gc GraphContext, resourceTemplate interfaces.ResourceTemplate) (interfaces.Resource, error) {
+	gc *GraphContext, resourceTemplate interfaces.ResourceTemplate) (interfaces.Resource, error) {
 	rd, ok := resDefs[kind+"/"+name]
 	if ok {
 		log.Printf("Found resource definition for %s/%s", kind, name)
-		return resourceTemplate.New(rd, sched.client, gc), nil
+		return resourceTemplate.New(rd, sched.client, *gc), nil
 	}
 
 	log.Printf("Resource definition for '%s/%s' not found, so it is expected to exist already", kind, name)
-	r := resourceTemplate.NewExisting(name, sched.client, gc)
+	r := resourceTemplate.NewExisting(name, sched.client, *gc)
 	if r == nil {
 		return nil, fmt.Errorf("existing resource %s/%s cannot be reffered", kind, name)
 	}
@@ -213,11 +222,69 @@ func NewDependencyGraph(sched *Scheduler, options interfaces.DependencyGraphOpti
 	}
 }
 
+func (sched *Scheduler) prepareContext(parentContext *GraphContext, dependency client.Dependency) *GraphContext {
+	context := &GraphContext{scheduler: sched, graph: parentContext.graph, flow: parentContext.flow}
+	context.args = make(map[string]string)
+	for key, value := range dependency.Args {
+		context.args[key] = copier.EvaluateString(value, parentContext.GetArg)
+	}
+	return context
+}
+
+func (sched *Scheduler) updateContext(context, parentContext *GraphContext, dependency client.Dependency) {
+	for key, value := range dependency.Args {
+		context.args[key] = copier.EvaluateString(value, parentContext.GetArg)
+	}
+}
+
+func (sched *Scheduler) newDefaultFlowObject() *client.Flow {
+	return &client.Flow{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Flow",
+			APIVersion: client.GroupName + "/" + client.Version,
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:      interfaces.DefaultFlowName,
+			Namespace: sched.client.Namespace(),
+		},
+		Exported: true,
+	}
+}
+
+func checkArgs(options interfaces.DependencyGraphOptions, flow *client.Flow) error {
+	if !options.AllowUndeclaredArgs {
+		for key := range options.Args {
+			if _, ok := flow.Parameters[key]; !ok {
+				return fmt.Errorf("unexpected argument %s", key)
+			}
+		}
+	}
+	for key, value := range flow.Parameters {
+		if value.Default == nil {
+			if _, ok := options.Args[key]; !ok {
+				return fmt.Errorf("mandatory argument %s was not provided", key)
+			}
+		}
+	}
+	return nil
+}
+
+func unique(slice []string) []string {
+	seen := map[string]bool{}
+	var result []string
+	for _, t := range slice {
+		if _, found := seen[t]; !found {
+			result = append(result, t)
+			seen[t] = true
+		}
+	}
+	return result
+}
+
 // BuildDependencyGraph loads dependencies data and creates the DependencyGraph
 func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphOptions) (interfaces.DependencyGraph, error) {
-	flowName := options.FlowName
-	if flowName == "" {
-		flowName = interfaces.DefaultFlowName
+	if options.FlowName == "" {
+		options.FlowName = interfaces.DefaultFlowName
 	}
 
 	log.Println("Getting resource definitions")
@@ -226,14 +293,24 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 		return nil, err
 	}
 
-	fullFlowName := "flow/" + flowName
-	flow, ok := resDefs[fullFlowName]
-	if !ok && flowName != interfaces.DefaultFlowName || ok && flow.Flow == nil {
-		return nil, fmt.Errorf("flow %s is not found", flowName)
+	fullFlowName := "flow/" + options.FlowName
+	flowResDef, ok := resDefs[fullFlowName]
+	if !ok && options.FlowName != interfaces.DefaultFlowName || ok && flowResDef.Flow == nil {
+		return nil, fmt.Errorf("flow %s is not found", options.FlowName)
 	}
 
-	if flow.Flow != nil && !flow.Flow.Exported && options.ExportedOnly {
-		return nil, fmt.Errorf("flow %s is not exported", flowName)
+	flow := flowResDef.Flow
+	if flow == nil {
+		flow = sched.newDefaultFlowObject()
+	}
+
+	if !flow.Exported && options.ExportedOnly {
+		return nil, fmt.Errorf("flow %s is not exported", options.FlowName)
+	}
+
+	err = checkArgs(options, flow)
+	if err != nil {
+		return nil, err
 	}
 
 	log.Println("Getting dependencies")
@@ -242,7 +319,7 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 		return nil, err
 	}
 
-	log.Println("Making sure there is no cycles in the depGraph")
+	log.Println("Making sure there is no cycles in the dependency graph")
 	if err = EnsureNoCycles(depList.Items); err != nil {
 		return nil, err
 	}
@@ -250,48 +327,85 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 	dependencies := groupDependencies(depList.Items, resDefs)
 
 	depGraph := NewDependencyGraph(sched, options)
+	rootContext := &GraphContext{scheduler: sched, graph: depGraph, flow: flow, args: options.Args}
 
 	if _, ok := dependencies[fullFlowName]; !ok {
-		log.Println("Flow depGraph is empty")
+		log.Printf("Flow %s is empty", options.FlowName)
 		return depGraph, nil
 	}
 
+	type Block struct {
+		dependency        client.Dependency
+		scheduledResource *ScheduledResource
+		parentContext     *GraphContext
+	}
+	blocks := map[string][]*Block{}
+
 	queue := list.New()
-	queue.PushFront(fullFlowName)
-	context := GraphContext{scheduler: sched, graph: depGraph}
+	queue.PushFront(&Block{dependency: client.Dependency{Child: fullFlowName}})
 
 	for e := queue.Front(); e != nil; e = e.Next() {
-		el := e.Value.(string)
+		parent := e.Value.(*Block)
 
-		deps := filterDependencies(dependencies, el, flow.Flow)
-		parent := depGraph.graph[el]
+		deps := filterDependencies(dependencies, parent.dependency.Child, flow)
 
 		for _, dep := range deps {
-			if parent != nil && strings.HasPrefix(parent.Key(), "flow/") {
+			if parent.scheduledResource != nil && strings.HasPrefix(parent.scheduledResource.Key(), "flow/") {
 				parentFlow := resDefs[dep.Parent]
 				if parentFlow.Flow != nil && canDependencyBelongToFlow(&dep, parentFlow.Flow) {
 					continue
 				}
 			}
-			sr := depGraph.graph[dep.Child]
-			if sr == nil {
-				kind, name, err := keyParts(dep.Child)
-				log.Printf("Adding resource %s to the flow dependency graph %s", dep.Child, flowName)
-
-				sr, err = sched.newScheduledResource(kind, name, resDefs, context)
-				if err != nil {
-					return nil, err
-				}
-				depGraph.graph[dep.Child] = sr
+			parentContext := rootContext
+			if parent.scheduledResource != nil {
+				parentContext = parent.scheduledResource.Context
 			}
 
-			if parent != nil {
-				sr.Requires = append(sr.Requires, parent)
-				parent.RequiredBy = append(parent.RequiredBy, sr)
-				sr.Meta[el] = dep.Meta
+			kind, name, err := keyParts(dep.Child)
+
+			context := sched.prepareContext(parentContext, dep)
+			sr, err := sched.newScheduledResource(kind, name, resDefs, context)
+			if err != nil {
+				return nil, err
 			}
-			queue.PushBack(dep.Child)
+
+			block := &Block{
+				scheduledResource: sr,
+				dependency:        dep,
+				parentContext:     parentContext,
+			}
+
+			blocks[dep.Child] = append(blocks[dep.Child], block)
+
+			if parent.scheduledResource != nil {
+				sr.Requires = append(sr.Requires, parent.scheduledResource.Key())
+				parent.scheduledResource.RequiredBy = append(parent.scheduledResource.RequiredBy, sr.Key())
+				sr.Meta[parent.dependency.Child] = dep.Meta
+			}
+			queue.PushBack(block)
 		}
+	}
+	for _, block := range blocks {
+		for _, entry := range block {
+			key := entry.scheduledResource.Key()
+			existingSr := depGraph.graph[key]
+			if existingSr == nil {
+				log.Printf("Adding resource %s to the dependency graph flow %s", key, options.FlowName)
+				depGraph.graph[key] = entry.scheduledResource
+			} else {
+				sched.updateContext(existingSr.Context, entry.parentContext, entry.dependency)
+				existingSr.Requires = append(existingSr.Requires, entry.scheduledResource.Requires...)
+				existingSr.RequiredBy = append(existingSr.RequiredBy, entry.scheduledResource.RequiredBy...)
+				for metaKey, metaValue := range entry.scheduledResource.Meta {
+					existingSr.Meta[metaKey] = metaValue
+				}
+			}
+		}
+	}
+
+	for _, value := range depGraph.graph {
+		value.RequiredBy = unique(value.RequiredBy)
+		value.Requires = unique(value.Requires)
 	}
 
 	return depGraph, nil

--- a/pkg/scheduler/dependency_graph.go
+++ b/pkg/scheduler/dependency_graph.go
@@ -18,7 +18,9 @@ import (
 	"container/list"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
 	"github.com/Mirantis/k8s-AppController/pkg/copier"
@@ -27,6 +29,7 @@ import (
 
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/fields"
 )
 
 // DependencyGraph is a full deployment depGraph as a mapping from job keys to
@@ -42,6 +45,7 @@ type GraphContext struct {
 	graph     *DependencyGraph
 	scheduler *Scheduler
 	flow      *client.Flow
+	replica   string
 }
 
 // Returns the Scheduler that was used to create the dependency graph
@@ -51,19 +55,24 @@ func (gc GraphContext) Scheduler() interfaces.Scheduler {
 
 // Returns argument values available in the current graph context
 func (gc GraphContext) GetArg(name string) string {
-	val, ok := gc.args[name]
-	if ok {
-		return val
+	switch name {
+	case "AC_NAME":
+		return gc.replica
+	default:
+		val, ok := gc.args[name]
+		if ok {
+			return val
+		}
+		val, ok = gc.graph.graphOptions.Args[name]
+		if ok {
+			return val
+		}
+		fp, ok := gc.flow.Parameters[name]
+		if ok && fp.Default != nil {
+			return *fp.Default
+		}
+		return ""
 	}
-	val, ok = gc.graph.graphOptions.Args[name]
-	if ok {
-		return val
-	}
-	fp, ok := gc.flow.Parameters[name]
-	if ok && fp.Default != nil {
-		return *fp.Default
-	}
-	return ""
 }
 
 // Returns the currently running dependency graph
@@ -81,6 +90,35 @@ func newScheduledResourceFor(r interfaces.Resource, context *GraphContext) *Sche
 		Meta:     map[string]map[string]string{},
 		Context:  context,
 	}
+}
+
+type DependencyList client.DependencyList
+
+func (d *DependencyList) Len() int {
+	return len(d.Items)
+}
+
+func (d *DependencyList) Less(i, j int) bool {
+	if d.Items[i].CreationTimestamp.Equal(d.Items[j].CreationTimestamp) {
+		return d.Items[i].UID < d.Items[j].UID
+	}
+	return d.Items[i].CreationTimestamp.Before(d.Items[j].CreationTimestamp)
+}
+
+func (d *DependencyList) Swap(i, j int) {
+	d.Items[i], d.Items[j] = d.Items[j], d.Items[i]
+}
+
+func (sched *Scheduler) getDependencies() ([]client.Dependency, error) {
+	depList, err := sched.client.Dependencies().List(api.ListOptions{LabelSelector: sched.selector})
+	if err != nil {
+		return nil, err
+	}
+	tmp := DependencyList(*depList)
+	sort.Stable(&tmp)
+
+	return tmp.Items, nil
+
 }
 
 func groupDependencies(dependencies []client.Dependency,
@@ -222,8 +260,8 @@ func NewDependencyGraph(sched *Scheduler, options interfaces.DependencyGraphOpti
 	}
 }
 
-func (sched *Scheduler) prepareContext(parentContext *GraphContext, dependency client.Dependency) *GraphContext {
-	context := &GraphContext{scheduler: sched, graph: parentContext.graph, flow: parentContext.flow}
+func (sched *Scheduler) prepareContext(parentContext *GraphContext, dependency client.Dependency, replica string) *GraphContext {
+	context := &GraphContext{scheduler: sched, graph: parentContext.graph, flow: parentContext.flow, replica: replica}
 	context.args = make(map[string]string)
 	for key, value := range dependency.Args {
 		context.args[key] = copier.EvaluateString(value, parentContext.GetArg)
@@ -281,6 +319,74 @@ func unique(slice []string) []string {
 	return result
 }
 
+type FlowDeploymentList client.FlowDeploymentList
+
+func (f *FlowDeploymentList) Len() int {
+	return len(f.Items)
+}
+
+func (f *FlowDeploymentList) Less(i, j int) bool {
+	if f.Items[i].CreationTimestamp.Equal(f.Items[j].CreationTimestamp) {
+		return f.Items[i].UID < f.Items[j].UID
+	}
+	return f.Items[i].CreationTimestamp.Before(f.Items[j].CreationTimestamp)
+}
+
+func (f *FlowDeploymentList) Swap(i, j int) {
+	f.Items[i], f.Items[j] = f.Items[j], f.Items[i]
+}
+
+func (sched *Scheduler) allocateReplicas(flow *client.Flow, label map[string]string) ([]string, error) {
+	existingReplicas, err := sched.client.FlowDeployments().List(api.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"flowName": flow.Name}),
+		LabelSelector: sched.selector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var maxCurrentTime time.Time
+	for _, item := range existingReplicas.Items {
+		if item.CreationTimestamp.After(maxCurrentTime) {
+			maxCurrentTime = item.CreationTimestamp.Time
+		}
+	}
+	tmp := FlowDeploymentList(*existingReplicas)
+
+	count := flow.ReplicaCount
+	if count < 1 {
+		count = 1
+	}
+
+	for len(tmp.Items) < count {
+		replica := &client.FlowDeployment{}
+		replica.GenerateName = strings.ToLower(flow.Name) + "-"
+		replica.FlowName = flow.Name
+		replica.Labels = label
+		replica.Namespace = sched.client.Namespace()
+		replica, err = sched.client.FlowDeployments().Create(replica)
+		if err != nil {
+			return nil, err
+		}
+		if !replica.CreationTimestamp.After(maxCurrentTime) {
+			time.Sleep(time.Second)
+			sched.client.FlowDeployments().Delete(replica.Name, nil)
+			continue
+		}
+		tmp.Items = append(tmp.Items, *replica)
+	}
+
+	sort.Stable(&tmp)
+	var result []string
+	for _, replica := range tmp.Items {
+		result = append(result, replica.ReplicaName())
+		if flow.ReplicaCount < 1 {
+			result[0] = ""
+			break
+		}
+	}
+	return result[:count], nil
+}
+
 // BuildDependencyGraph loads dependencies data and creates the DependencyGraph
 func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphOptions) (interfaces.DependencyGraph, error) {
 	if options.FlowName == "" {
@@ -314,17 +420,17 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 	}
 
 	log.Println("Getting dependencies")
-	depList, err := sched.client.Dependencies().List(api.ListOptions{LabelSelector: sched.selector})
+	depList, err := sched.getDependencies()
 	if err != nil {
 		return nil, err
 	}
 
 	log.Println("Making sure there is no cycles in the dependency graph")
-	if err = EnsureNoCycles(depList.Items); err != nil {
+	if err = EnsureNoCycles(depList); err != nil {
 		return nil, err
 	}
 
-	dependencies := groupDependencies(depList.Items, resDefs)
+	dependencies := groupDependencies(depList, resDefs)
 
 	depGraph := NewDependencyGraph(sched, options)
 	rootContext := &GraphContext{scheduler: sched, graph: depGraph, flow: flow, args: options.Args}
@@ -339,65 +445,73 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 		scheduledResource *ScheduledResource
 		parentContext     *GraphContext
 	}
+
+	replicas, err := sched.allocateReplicas(flow, flowResDef.Labels)
+	if err != nil {
+		return nil, err
+	}
+
 	blocks := map[string][]*Block{}
 
-	queue := list.New()
-	queue.PushFront(&Block{dependency: client.Dependency{Child: fullFlowName}})
+	for _, replica := range replicas {
+		queue := list.New()
+		queue.PushFront(&Block{dependency: client.Dependency{Child: fullFlowName}})
 
-	for e := queue.Front(); e != nil; e = e.Next() {
-		parent := e.Value.(*Block)
+		for e := queue.Front(); e != nil; e = e.Next() {
+			parent := e.Value.(*Block)
 
-		deps := filterDependencies(dependencies, parent.dependency.Child, flow)
+			deps := filterDependencies(dependencies, parent.dependency.Child, flow)
 
-		for _, dep := range deps {
-			if parent.scheduledResource != nil && strings.HasPrefix(parent.scheduledResource.Key(), "flow/") {
-				parentFlow := resDefs[dep.Parent]
-				if parentFlow.Flow != nil && canDependencyBelongToFlow(&dep, parentFlow.Flow) {
-					continue
+			for _, dep := range deps {
+				if parent.scheduledResource != nil && strings.HasPrefix(parent.scheduledResource.Key(), "flow/") {
+					parentFlow := resDefs[dep.Parent]
+					if parentFlow.Flow != nil && canDependencyBelongToFlow(&dep, parentFlow.Flow) {
+						continue
+					}
 				}
-			}
-			parentContext := rootContext
-			if parent.scheduledResource != nil {
-				parentContext = parent.scheduledResource.Context
-			}
+				parentContext := rootContext
+				if parent.scheduledResource != nil {
+					parentContext = parent.scheduledResource.Context
+				}
 
-			kind, name, err := keyParts(dep.Child)
+				kind, name, err := keyParts(dep.Child)
 
-			context := sched.prepareContext(parentContext, dep)
-			sr, err := sched.newScheduledResource(kind, name, resDefs, context)
-			if err != nil {
-				return nil, err
+				context := sched.prepareContext(parentContext, dep, replica)
+				sr, err := sched.newScheduledResource(kind, name, resDefs, context)
+				if err != nil {
+					return nil, err
+				}
+
+				block := &Block{
+					scheduledResource: sr,
+					dependency:        dep,
+					parentContext:     parentContext,
+				}
+
+				blocks[dep.Child] = append(blocks[dep.Child], block)
+
+				if parent.scheduledResource != nil {
+					sr.Requires = append(sr.Requires, parent.scheduledResource.Key())
+					parent.scheduledResource.RequiredBy = append(parent.scheduledResource.RequiredBy, sr.Key())
+					sr.Meta[parent.dependency.Child] = dep.Meta
+				}
+				queue.PushBack(block)
 			}
-
-			block := &Block{
-				scheduledResource: sr,
-				dependency:        dep,
-				parentContext:     parentContext,
-			}
-
-			blocks[dep.Child] = append(blocks[dep.Child], block)
-
-			if parent.scheduledResource != nil {
-				sr.Requires = append(sr.Requires, parent.scheduledResource.Key())
-				parent.scheduledResource.RequiredBy = append(parent.scheduledResource.RequiredBy, sr.Key())
-				sr.Meta[parent.dependency.Child] = dep.Meta
-			}
-			queue.PushBack(block)
 		}
-	}
-	for _, block := range blocks {
-		for _, entry := range block {
-			key := entry.scheduledResource.Key()
-			existingSr := depGraph.graph[key]
-			if existingSr == nil {
-				log.Printf("Adding resource %s to the dependency graph flow %s", key, options.FlowName)
-				depGraph.graph[key] = entry.scheduledResource
-			} else {
-				sched.updateContext(existingSr.Context, entry.parentContext, entry.dependency)
-				existingSr.Requires = append(existingSr.Requires, entry.scheduledResource.Requires...)
-				existingSr.RequiredBy = append(existingSr.RequiredBy, entry.scheduledResource.RequiredBy...)
-				for metaKey, metaValue := range entry.scheduledResource.Meta {
-					existingSr.Meta[metaKey] = metaValue
+		for _, block := range blocks {
+			for _, entry := range block {
+				key := entry.scheduledResource.Key()
+				existingSr := depGraph.graph[key]
+				if existingSr == nil {
+					log.Printf("Adding resource %s to the dependency graph flow %s", key, options.FlowName)
+					depGraph.graph[key] = entry.scheduledResource
+				} else {
+					sched.updateContext(existingSr.Context, entry.parentContext, entry.dependency)
+					existingSr.Requires = append(existingSr.Requires, entry.scheduledResource.Requires...)
+					existingSr.RequiredBy = append(existingSr.RequiredBy, entry.scheduledResource.RequiredBy...)
+					for metaKey, metaValue := range entry.scheduledResource.Meta {
+						existingSr.Meta[metaKey] = metaValue
+					}
 				}
 			}
 		}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -72,9 +72,9 @@ func TestBuildDependencyGraph(t *testing.T) {
 			sr.Key(), 1, len(sr.Requires))
 	}
 
-	if sr.RequiredBy[0].Key() != "pod/ready-2" {
+	if sr.RequiredBy[0] != "pod/ready-2" {
 		t.Errorf("wrong value of 'RequiredBy' for scheduled resource '%s', expected '%s', actual '%s'",
-			sr.Key(), "pod/ready-2", sr.RequiredBy[0].Key())
+			sr.Key(), "pod/ready-2", sr.RequiredBy[0])
 		return
 	}
 
@@ -95,9 +95,9 @@ func TestBuildDependencyGraph(t *testing.T) {
 			sr.Key(), 1, len(sr.Requires))
 	}
 
-	if sr.Requires[0].Key() != "pod/ready-1" {
+	if sr.Requires[0] != "pod/ready-1" {
 		t.Errorf("wrong value of 'Requires' for scheduled resource '%s', expected '%s', actual '%s'",
-			sr.Key(), "pod/ready-1", sr.Requires[0].Key())
+			sr.Key(), "pod/ready-1", sr.Requires[0])
 	}
 
 	if len(sr.RequiredBy) != 0 {
@@ -107,10 +107,16 @@ func TestBuildDependencyGraph(t *testing.T) {
 }
 
 func TestIsBlocked(t *testing.T) {
+	depGraph := NewDependencyGraph(nil, interfaces.DependencyGraphOptions{})
+	context := &GraphContext{graph: depGraph}
+
 	one := &ScheduledResource{
 		Resource: report.SimpleReporter{BaseResource: mocks.NewResource("fake1", "not ready")},
 		Meta:     map[string]map[string]string{},
+		Context:  context,
 	}
+
+	depGraph.graph["fake1"] = one
 
 	if one.IsBlocked() {
 		t.Error("scheduled resource is blocked but it must not")
@@ -119,9 +125,12 @@ func TestIsBlocked(t *testing.T) {
 	two := &ScheduledResource{
 		Resource: report.SimpleReporter{BaseResource: mocks.NewResource("fake2", "ready")},
 		Meta:     map[string]map[string]string{},
+		Context:  context,
 	}
 
-	one.Requires = []*ScheduledResource{two}
+	depGraph.graph["fake2"] = two
+
+	one.Requires = []string{"fake2"}
 
 	if one.IsBlocked() {
 		t.Error("scheduled resource is blocked but it must not")
@@ -132,24 +141,30 @@ func TestIsBlocked(t *testing.T) {
 		t.Error("scheduled resource is not blocked but it must be")
 	}
 
-	three := &ScheduledResource{
+	depGraph.graph["fake3"] = &ScheduledResource{
 		Resource: report.SimpleReporter{mocks.NewResource("fake3", "not ready")},
 		Meta:     map[string]map[string]string{},
+		Context:  context,
 	}
 
 	two.Error = nil
-	one.Requires = append(one.Requires, three)
+	one.Requires = append(one.Requires, "fake3")
 
 	if !one.IsBlocked() {
-		t.Errorf("scheduled resource is not blocked but it must be")
+		t.Error("scheduled resource is not blocked but it must be")
 	}
 }
 
 func TestIsBlockedWithOnErrorDependency(t *testing.T) {
+	depGraph := NewDependencyGraph(nil, interfaces.DependencyGraphOptions{})
+	context := &GraphContext{graph: depGraph}
+
 	one := &ScheduledResource{
 		Resource: report.SimpleReporter{BaseResource: mocks.NewResource("fake1", "not ready")},
 		Meta:     map[string]map[string]string{},
+		Context:  context,
 	}
+	depGraph.graph["fake1"] = one
 
 	if one.IsBlocked() {
 		t.Error("scheduled resource is blocked but it must be not")
@@ -158,9 +173,11 @@ func TestIsBlockedWithOnErrorDependency(t *testing.T) {
 	two := &ScheduledResource{
 		Resource: report.SimpleReporter{BaseResource: mocks.NewResource("fake2", "not ready")},
 		Meta:     map[string]map[string]string{},
+		Context:  context,
 	}
+	depGraph.graph["fake2"] = two
 
-	one.Requires = []*ScheduledResource{two}
+	one.Requires = []string{"fake2"}
 	one.Meta["fake2"] = map[string]string{"on-error": "true"}
 
 	if !one.IsBlocked() {
@@ -303,7 +320,8 @@ func TestLimitConcurrency(t *testing.T) {
 		for i := 0; i < 15; i++ {
 			key := fmt.Sprintf("resource%d", i)
 			r := report.SimpleReporter{BaseResource: mocks.NewCountingResource(key, counter, time.Second/4)}
-			sr := newScheduledResourceFor(r)
+			context := &GraphContext{graph: depGraph}
+			sr := newScheduledResourceFor(r, context)
 			depGraph.graph[sr.Key()] = sr
 		}
 		stopChan := make(chan struct{})

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -38,7 +38,7 @@ func TestBuildDependencyGraph(t *testing.T) {
 
 	sched := New(c, nil, 0)
 
-	dg, err := sched.BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	dg, err := sched.BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Error(err)
 		return
@@ -298,7 +298,7 @@ func TestLimitConcurrency(t *testing.T) {
 		counter := mocks.NewCounterWithMemo()
 
 		sched := &Scheduler{concurrency: concurrency}
-		depGraph := NewDependencyGraph(sched)
+		depGraph := NewDependencyGraph(sched, interfaces.DependencyGraphOptions{})
 
 		for i := 0; i < 15; i++ {
 			key := fmt.Sprintf("resource%d", i)
@@ -320,7 +320,7 @@ func TestLimitConcurrency(t *testing.T) {
 }
 
 func TestStopBeforeDeploymentStarted(t *testing.T) {
-	depGraph := NewDependencyGraph(&Scheduler{})
+	depGraph := NewDependencyGraph(&Scheduler{}, interfaces.DependencyGraphOptions{})
 	sr := &ScheduledResource{
 		Resource: report.SimpleReporter{BaseResource: mocks.NewResource("fake1", "not ready")},
 	}
@@ -371,7 +371,7 @@ func TestGraphAllResourceTypes(t *testing.T) {
 		mocks.MakeDependency("pod/ready-1", "serviceaccount/sa-1"),
 	)
 
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestGraphAllResourceTypes(t *testing.T) {
 
 func TestEmptyStatus(t *testing.T) {
 	c := mocks.NewClient()
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestPreparedStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/1", "job/2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestRunningStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/ready-1", "job/2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,7 +452,7 @@ func TestFinishedStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/ready-1", "job/ready-2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestGraph(t *testing.T) {
 		mocks.MakeDependency("job/ready-2", "job/1"),
 		mocks.MakeDependency("job/3", "job/1"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DefaultFlowName, nil)
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR makes it possible to have resource definitions
with generateName instead of name and refer to them by that
name in graph dependencies.

When generateName is used k8s appends random suffix to that name
so that unique object is produced each time. Thus when resources
with generateName are used in the graph, each deployment of the graph
produces new resources and is no longer idempotent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/229)
<!-- Reviewable:end -->
