### PR TITLE
Replication of flows

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -115,7 +115,7 @@ func bootstrap(cmd *cobra.Command, args []string) {
 
 	checkVersion(c)
 
-	manifests := [...]string{"dependencies.json", "resdefs.json"}
+	manifests := [...]string{"dependencies.json", "resdefs.json", "replicas.json"}
 
 	for _, manifest := range manifests {
 		dependency := getDependencyFromPath(thirdPartyResourcesPath + "/" + manifest)

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -32,5 +32,8 @@ type DataExtractor struct {
 }
 
 func normalizeName(name string) string {
-	return strings.ToLower(strings.Replace(name, "$", "", -1))
+	for k, v := range map[string]string{"$": "", "_": "-"} {
+		name = strings.Replace(name, k, v, -1)
+	}
+	return strings.ToLower(name)
 }

--- a/manifests/replicas.json
+++ b/manifests/replicas.json
@@ -1,0 +1,13 @@
+{
+	"metadata": {
+		"name": "replica.appcontroller.k8s"
+	},
+	"apiVersion": "extensions/v1beta1",
+	"kind": "ThirdPartyResource",
+	"description": "AppController flow replica",
+	"versions": [
+		{
+			"name": "v1alpha1"
+		}
+	]
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,6 +59,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		SchemeGroupVersion,
 		&Dependency{},
 		&DependencyList{},
+		&Replica{},
+		&ReplicaList{},
 	)
 	return nil
 }
@@ -94,6 +96,7 @@ type Interface interface {
 
 	Dependencies() DependenciesInterface
 	ResourceDefinitions() ResourceDefinitionsInterface
+	Replicas() ReplicasInterface
 
 	IsEnabled(version unversioned.GroupVersion) bool
 	Namespace() string
@@ -104,6 +107,7 @@ type Client struct {
 	alphaApps           v1alpha1.AppsInterface
 	dependencies        DependenciesInterface
 	resourceDefinitions ResourceDefinitionsInterface
+	replicas            ReplicasInterface
 	namespace           string
 	apiVersions         *unversioned.APIGroupList
 }
@@ -179,7 +183,12 @@ func (c Client) PersistentVolumeClaims() corev1.PersistentVolumeClaimInterface {
 	return c.clientset.Core().PersistentVolumeClaims(c.namespace)
 }
 
-// Namespace returns current namespace for the client
+// Replicas return interface to access flow deployments
+func (c Client) Replicas() ReplicasInterface {
+	return c.replicas
+}
+
+// Returns AC namespace
 func (c Client) Namespace() string {
 	return c.namespace
 }
@@ -211,6 +220,10 @@ func newForConfig(c rest.Config, namespace string) (Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+	replicas, err := newReplicas(c, namespace)
+	if err != nil {
+		return nil, err
+	}
 	cl, err := kubernetes.NewForConfig(&c)
 	if err != nil {
 		return nil, err
@@ -224,7 +237,7 @@ func newForConfig(c rest.Config, namespace string) (Interface, error) {
 		return nil, err
 	}
 
-	return NewClient(cl, apps, deps, resdefs, namespace, versions), nil
+	return NewClient(cl, apps, deps, resdefs, replicas, namespace, versions), nil
 }
 
 // Client class constructor
@@ -233,6 +246,7 @@ func NewClient(
 	alphaApps v1alpha1.AppsInterface,
 	dependencies DependenciesInterface,
 	resourceDefinitions ResourceDefinitionsInterface,
+	replicas ReplicasInterface,
 	namespace string,
 	apiVersions *unversioned.APIGroupList) Interface {
 
@@ -241,6 +255,7 @@ func NewClient(
 		alphaApps:           alphaApps,
 		dependencies:        dependencies,
 		resourceDefinitions: resourceDefinitions,
+		replicas:            replicas,
 		namespace:           namespace,
 		apiVersions:         apiVersions,
 	}

--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -15,10 +15,17 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/rest"
 )
 
+// Flow is a pseudo-resource (i.e. it looks like resource but cannot be created in k8s, but can be wrapped with
+// ResourceDefinition), that represents the scope and parameters of the named reusable subgraph.
 type Flow struct {
 	unversioned.TypeMeta `json:",inline"`
 
@@ -40,6 +47,7 @@ type Flow struct {
 	Parameters map[string]FlowParameter `json:"parameters,omitempty"`
 }
 
+// FlowParameter represents declaration of a parameter that flow can accept (its description, default value etc)
 type FlowParameter struct {
 	// Optional default value for the parameter. If the declared parameter has nil Default then the argument for
 	// this parameter becomes mandatory (i.e. it MUST be provided)
@@ -47,4 +55,99 @@ type FlowParameter struct {
 
 	// Description of the parameter (help string)
 	Description string `json:"description,omitempty"`
+}
+
+// Replica resource represents one instance of the replicated flow. Since the only difference between replicas is their
+// $AC_NAME value which is replica name this resource is only needed to generate unique name for each replica and make
+// those name persistent so that we could do CRD (CRUD without "U") on the list of replica names
+type Replica struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard object metadata
+	api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	FlowName string `json:"flowName,omitempty"`
+}
+
+// ReplicaList is a list of replicas
+type ReplicaList struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Standard list metadata.
+	unversioned.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Items []Replica `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+// ReplicasInterface is an interface to access flow replica objects
+type ReplicasInterface interface {
+	List(opts api.ListOptions) (*ReplicaList, error)
+	Create(replica *Replica) (*Replica, error)
+	Delete(name string) error
+}
+
+type replicas struct {
+	rc        *rest.RESTClient
+	namespace string
+}
+
+func newReplicas(c rest.Config, ns string) (*replicas, error) {
+	rc, err := thirdPartyResourceRESTClient(&c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &replicas{rc, ns}, nil
+}
+
+// List returns a list of flow replicas stored in k8s
+func (r *replicas) List(opts api.ListOptions) (*ReplicaList, error) {
+	resp, err := r.rc.Get().
+		Namespace(r.namespace).
+		Resource("replicas").
+		LabelsSelectorParam(opts.LabelSelector).
+		DoRaw()
+
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ReplicaList{}
+	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// Create stores new replica object in the k8s
+func (r *replicas) Create(replica *Replica) (result *Replica, err error) {
+	result = &Replica{}
+	data, err := r.rc.Post().
+		Resource("replicas").
+		Namespace(r.namespace).
+		Body(replica).
+		Do().Raw()
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, result)
+	return
+}
+
+// Delete deletes a replica object by its name
+func (r *replicas) Delete(name string) error {
+	return r.rc.Delete().
+		Namespace(r.namespace).
+		Resource("replicas").
+		Name(name).
+		Do().
+		Error()
+}
+
+// ReplicaName returns replica name (which then goes into $AC_NAME var) encoded in Replica k8s object name
+// this is done in order to take advantage of GenerateName field which makes k8s generate
+// unique name that cannot collide with other replicas
+func (r *Replica) ReplicaName() string {
+	return r.Name[1+strings.LastIndex(r.Name, "-"):]
 }

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -78,10 +78,12 @@ type GraphContext interface {
 }
 
 type DependencyGraphOptions struct {
-	FlowName            string
-	Args                map[string]string
-	ExportedOnly        bool
-	AllowUndeclaredArgs bool
+	FlowName               string
+	Args                   map[string]string
+	ExportedOnly           bool
+	AllowUndeclaredArgs    bool
+	ReplicaCount           int
+	ReplicaCountIsRelative bool
 }
 
 type Scheduler interface {

--- a/pkg/mocks/client.go
+++ b/pkg/mocks/client.go
@@ -30,12 +30,14 @@ func newClient(apiVersions *unversioned.APIGroupList, objects ...runtime.Object)
 	fakeClientset := fake.NewSimpleClientset(objects...)
 	apps := &alphafake.FakeApps{&fakeClientset.Fake}
 	deps := &FakeDeps{fake: &fakeClientset.Fake, ns: ns}
+	replicas := &FakeReplicas{fake: &fakeClientset.Fake, ns: ns}
 	resDefs := &FakeResDef{fake: &fakeClientset.Fake, ns: ns}
 	return client.NewClient(
 		fakeClientset,
 		apps,
 		deps,
 		resDefs,
+		replicas,
 		ns,
 		apiVersions)
 }

--- a/pkg/mocks/fake_dependencies.go
+++ b/pkg/mocks/fake_dependencies.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// FakeFlows implements DependenciesInterface
+// FakeDeps implements DependenciesInterface
 type FakeDeps struct {
 	fake *testing.Fake
 	ns   string

--- a/pkg/mocks/fake_replicas.go
+++ b/pkg/mocks/fake_replicas.go
@@ -1,0 +1,124 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/labels"
+	"k8s.io/client-go/pkg/types"
+	"k8s.io/client-go/testing"
+)
+
+// FakeReplicas implements ReplicaInterface
+type FakeReplicas struct {
+	fake *testing.Fake
+	ns   string
+}
+
+var replicaResource = unversioned.GroupVersionResource{
+	Group:    "appcontroller.k8s",
+	Version:  "v1alpha1",
+	Resource: "deployments",
+}
+
+func (fr *FakeReplicas) Create(replica *client.Replica) (result *client.Replica, err error) {
+	obj, err := fr.fake.
+		Invokes(testing.NewCreateAction(replicaResource, fr.ns, replica), &client.Replica{})
+
+	if obj == nil {
+		return nil, err
+	}
+	res := obj.(*client.Replica)
+	res.SetCreationTimestamp(unversioned.Time{time.Now()})
+	uuid, _ := newUUID()
+	res.SetUID(types.UID(uuid))
+
+	return res, err
+}
+
+func (fr *FakeReplicas) Update(replica *client.Replica) (result *client.Replica, err error) {
+	obj, err := fr.fake.
+		Invokes(testing.NewUpdateAction(replicaResource, fr.ns, replica), &client.Replica{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*client.Replica), err
+}
+
+func (fr *FakeReplicas) Delete(name string) error {
+	_, err := fr.fake.
+		Invokes(testing.NewDeleteAction(replicaResource, fr.ns, name), &client.Replica{})
+
+	return err
+}
+
+func (fr *FakeReplicas) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(replicaResource, fr.ns, listOptions)
+
+	_, err := fr.fake.Invokes(action, &client.Replica{})
+	return err
+}
+
+func (fr *FakeReplicas) Get(name string) (result *client.Replica, err error) {
+	obj, err := fr.fake.
+		Invokes(testing.NewGetAction(replicaResource, fr.ns, name), &client.Replica{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*client.Replica), err
+}
+
+func (fr *FakeReplicas) List(opts api.ListOptions) (result *client.ReplicaList, err error) {
+	obj, err := fr.fake.
+		Invokes(testing.NewListAction(replicaResource, fr.ns, opts), &client.ReplicaList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &client.ReplicaList{}
+	for _, item := range obj.(*client.ReplicaList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+func newUUID() (string, error) {
+	uuid := make([]byte, 16)
+	n, err := io.ReadFull(rand.Reader, uuid)
+	if n != len(uuid) || err != nil {
+		return "", err
+	}
+	// variant bits; see section 4.1.1
+	uuid[8] = uuid[8]&^0xc0 | 0x80
+	// version 4 (pseudo-random); see section 4.1.3
+	uuid[6] = uuid[6]&^0xf0 | 0x40
+	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -38,7 +38,7 @@ func TestBuildDependencyGraph(t *testing.T) {
 
 	sched := New(c, nil, 0)
 
-	dg, err := sched.BuildDependencyGraph(interfaces.DependencyGraphOptions{})
+	dg, err := sched.BuildDependencyGraph(interfaces.DependencyGraphOptions{ReplicaCount: 1})
 	if err != nil {
 		t.Error(err)
 		return
@@ -389,7 +389,8 @@ func TestGraphAllResourceTypes(t *testing.T) {
 		mocks.MakeDependency("pod/ready-1", "serviceaccount/sa-1"),
 	)
 
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +431,8 @@ func TestPreparedStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/1", "job/2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -450,7 +452,8 @@ func TestRunningStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/ready-1", "job/2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,7 +473,8 @@ func TestFinishedStatus(t *testing.T) {
 
 		mocks.MakeDependency("job/ready-1", "job/ready-2"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +498,8 @@ func TestGraph(t *testing.T) {
 		mocks.MakeDependency("job/ready-2", "job/1"),
 		mocks.MakeDependency("job/3", "job/1"),
 	)
-	depGraph, err := New(c, nil, 0).BuildDependencyGraph(interfaces.DependencyGraphOptions{})
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 1})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Flows can now be replicated. Each flow replica gets a unique name
which is available through the $AC_NAME variable.

In order for a replica to get the same name on each run, new
FlowDeployment (Deployment.appcontroller.k8s) TPR is created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/230)
<!-- Reviewable:end -->
