### PR TITLE
get-status improvements

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/pkg/labels"
 )
 
-var argRe, _ = regexp.Compile(`\s*(\w+)\W+(.*)`)
+var argRe = regexp.MustCompile(`\s*(\w+)\W+(.*)`)
 
 func run(cmd *cobra.Command, args []string) {
 	concurrency, err := cmd.Flags().GetInt("concurrency")
@@ -146,7 +146,7 @@ func getLabelSelector(cmd *cobra.Command) (string, error) {
 // InitRunCommand returns cobra command for creating AppController graph deployment
 func InitRunCommand() (*cobra.Command, error) {
 	run := &cobra.Command{
-		Use:   "run",
+		Use:   "run [flow-name]",
 		Short: "Create deployment of AppController graph flow",
 		Long:  "Create deployment of AppController graph flow",
 		Run:   run,

--- a/e2e/example_runner.go
+++ b/e2e/example_runner.go
@@ -112,16 +112,13 @@ func (f *ExamplesFramework) VerifyStatus(task string) {
 			if err == nil {
 				return false
 			}
-			depGraph, err := scheduler.New(f.Client, nil, 0).BuildDependencyGraph(
-				interfaces.DependencyGraphOptions{})
+			status, r, err := scheduler.GetStatus(f.Client, nil, interfaces.DependencyGraphOptions{})
 			if err != nil {
 				return false
 			}
-			var status interfaces.DeploymentStatus
-			status, r := depGraph.GetStatus()
 			depReport = r.(report.DeploymentReport)
 			utils.Logf("STATUS: %s\n", status)
-			return status == interfaces.Finished
+			return status == interfaces.Finished || status == interfaces.Empty
 		},
 		240*time.Second, 5*time.Second).Should(BeTrue(), strings.Join(depReport.AsText(0), "\n"))
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -203,7 +203,6 @@ func (c Client) IsEnabled(version unversioned.GroupVersion) bool {
 		}
 		for _, v := range group.Versions {
 			if v.Version == version.Version {
-				log.Printf("Found version %v and group %v", group.Name, v.Version)
 				return true
 			}
 		}

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -154,7 +154,7 @@ func podsStateFromLabels(apiClient client.Interface, objLabels map[string]string
 	resources := make([]interfaces.BaseResource, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		p := pod
-		resources = append(resources, NewPod(&p, apiClient.Pods(), nil))
+		resources = append(resources, newPod(&p, apiClient.Pods(), nil))
 	}
 
 	status, err := resourceListStatus(resources)

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -88,7 +88,6 @@ func getKeys(m map[string]interfaces.ResourceTemplate) (keys []string) {
 
 func resourceListStatus(resources []interfaces.BaseResource) (interfaces.ResourceStatus, error) {
 	for _, r := range resources {
-		log.Printf("Checking status for resource %s", r.Key())
 		status, err := r.Status(nil)
 		if err != nil {
 			return interfaces.ResourceError, err

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -39,7 +39,7 @@ type ExistingConfigMap struct {
 
 type configMapTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a configmap
+// ShortName returns wrapped resource name if it was a configmap
 func (configMapTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.ConfigMap == nil {
 		return ""
@@ -47,25 +47,27 @@ func (configMapTemplateFactory) ShortName(definition client.ResourceDefinition) 
 	return definition.ConfigMap.Name
 }
 
-// k8s resource kind that this fabric supports
+// Kind returns a k8s resource kind that this fabric supports
 func (configMapTemplateFactory) Kind() string {
 	return "configmap"
 }
 
-// New returns a new object wrapped as Resource
-func (configMapTemplateFactory) New(def client.ResourceDefinition, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewConfigMap(parametrizeResource(def.ConfigMap, gc).(*v1.ConfigMap), ci.ConfigMaps(), def.Meta)
+// New returns ConfigMap controller for new resource based on resource definition
+func (configMapTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
+	cm := parametrizeResource(def.ConfigMap, gc).(*v1.ConfigMap)
+	return report.SimpleReporter{BaseResource: ConfigMap{Base: Base{def.Meta}, ConfigMap: cm, Client: c.ConfigMaps()}}
 }
 
-// NewExisting returns a new object based on existing one wrapped as Resource
+// NewExisting returns ConfigMap controller for existing resource by its name
 func (configMapTemplateFactory) NewExisting(name string, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewExistingConfigMap(name, ci.ConfigMaps())
+	return report.SimpleReporter{BaseResource: ExistingConfigMap{Name: name, Client: ci.ConfigMaps()}}
 }
 
 func configMapKey(name string) string {
 	return "configmap/" + name
 }
 
+// Key returns the ConfigMap object identifier
 func (c ConfigMap) Key() string {
 	return configMapKey(c.ConfigMap.Name)
 }
@@ -84,6 +86,7 @@ func (c ConfigMap) Status(meta map[string]string) (interfaces.ResourceStatus, er
 	return configMapStatus(c.Client, c.ConfigMap.Name)
 }
 
+// Create looks for DaemonSet in k8s and creates it if not present
 func (c ConfigMap) Create() error {
 	if err := checkExistence(c); err != nil {
 		log.Println("Creating", c.Key())
@@ -93,18 +96,12 @@ func (c ConfigMap) Create() error {
 	return nil
 }
 
+// Delete deletes ConfigMap from the cluster
 func (c ConfigMap) Delete() error {
 	return c.Client.Delete(c.ConfigMap.Name, &v1.DeleteOptions{})
 }
 
-func NewConfigMap(c *v1.ConfigMap, client corev1.ConfigMapInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ConfigMap{Base: Base{meta}, ConfigMap: c, Client: client}}
-}
-
-func NewExistingConfigMap(name string, client corev1.ConfigMapInterface) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ExistingConfigMap{Name: name, Client: client}}
-}
-
+// Key returns the ConfigMap object identifier
 func (c ExistingConfigMap) Key() string {
 	return configMapKey(c.Name)
 }
@@ -114,10 +111,12 @@ func (c ExistingConfigMap) Status(meta map[string]string) (interfaces.ResourceSt
 	return configMapStatus(c.Client, c.Name)
 }
 
+// Create looks for existing ConfigMap and returns an error if there is no such ConfigMap in a cluster
 func (c ExistingConfigMap) Create() error {
 	return createExistingResource(c)
 }
 
+// Delete deletes ConfigMap from the cluster
 func (c ExistingConfigMap) Delete() error {
 	return c.Client.Delete(c.Name, nil)
 }

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -28,9 +28,9 @@ type Flow struct {
 	Base
 	flow          *client.Flow
 	context       interfaces.GraphContext
-	status        interfaces.ResourceStatus
 	generatedName string
 	originalName  string
+	currentGraph  interfaces.DependencyGraph
 }
 
 type flowTemplateFactory struct{}
@@ -63,7 +63,6 @@ func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface
 			Base:          Base{def.Meta},
 			flow:          newFlow,
 			context:       gc,
-			status:        interfaces.ResourceNotReady,
 			generatedName: fmt.Sprintf("%s-%s%s", newFlow.Name, depName, gc.GetArg("AC_NAME")),
 			originalName:  def.Flow.Name,
 		}}
@@ -80,7 +79,7 @@ func (f Flow) Key() string {
 	return "flow/" + f.generatedName
 }
 
-func (f *Flow) buildDependencyGraph(decreaseReplicaCount bool) (interfaces.DependencyGraph, error) {
+func (f *Flow) buildDependencyGraph(replicaCountDelta, minReplicaCount int, silent bool) (interfaces.DependencyGraph, error) {
 	args := map[string]string{}
 	for arg := range f.flow.Parameters {
 		val := f.context.GetArg(arg)
@@ -92,15 +91,9 @@ func (f *Flow) buildDependencyGraph(decreaseReplicaCount bool) (interfaces.Depen
 		FlowName:         f.originalName,
 		Args:             args,
 		FlowInstanceName: f.generatedName,
-	}
-
-	if decreaseReplicaCount {
-		// Delete one replica
-		options.ReplicaCount = -1
-	} else {
-		// Recheck existing replica resources or create one replica if none exist
-		options.ReplicaCount = 0
-		options.MinReplicaCount = 1
+		ReplicaCount:     replicaCountDelta,
+		MinReplicaCount:  minReplicaCount,
+		Silent:           silent,
 	}
 
 	graph, err := f.context.Scheduler().BuildDependencyGraph(options)
@@ -118,14 +111,19 @@ func (f *Flow) buildDependencyGraph(decreaseReplicaCount bool) (interfaces.Depen
 // all subsequent calls will do nothing but check the state of the resources from this replica (and recreate them,
 // if they were deleted manually between the calls), which makes Create() be idempotent
 func (f *Flow) Create() error {
-	graph, err := f.buildDependencyGraph(false)
-	if err != nil {
-		return err
+	graph := f.currentGraph
+
+	if graph == nil {
+		var err error
+		graph, err = f.buildDependencyGraph(0, 1, false)
+		if err != nil {
+			return err
+		}
+		f.currentGraph = graph
 	}
 	go func() {
 		stopChan := make(chan struct{})
 		graph.Deploy(stopChan)
-		f.status = interfaces.ResourceReady
 	}()
 	return nil
 }
@@ -135,17 +133,38 @@ func (f *Flow) Create() error {
 // Delete is called during dlow destruction which can happen only once while Create ensures that at least one flow
 // replica exists, and as such can be called any number of times
 func (f Flow) Delete() error {
-	graph, err := f.buildDependencyGraph(true)
+	graph, err := f.buildDependencyGraph(-1, 0, false)
 	if err != nil {
 		return err
 	}
 	stopChan := make(chan struct{})
 	graph.Deploy(stopChan)
-	f.status = interfaces.ResourceReady
 	return nil
 }
 
 // Current status of the flow deployment
 func (f Flow) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
-	return f.status, nil
+	graph := f.currentGraph
+	if graph == nil {
+		var err error
+		graph, err = f.buildDependencyGraph(0, 0, true)
+		if err != nil {
+			return interfaces.ResourceError, err
+		}
+	}
+
+	status, _ := graph.GetStatus()
+
+	switch status {
+	case interfaces.Empty:
+		fallthrough
+	case interfaces.Finished:
+		return interfaces.ResourceReady, nil
+	case interfaces.Prepared:
+		fallthrough
+	case interfaces.Running:
+		return interfaces.ResourceNotReady, nil
+	default:
+		return interfaces.ResourceError, nil
+	}
 }

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -35,7 +35,7 @@ type Flow struct {
 
 type flowTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a flow
+// ShortName returns wrapped resource name if it was a flow
 func (flowTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.Flow == nil {
 		return ""
@@ -43,12 +43,12 @@ func (flowTemplateFactory) ShortName(definition client.ResourceDefinition) strin
 	return definition.Flow.Name
 }
 
-// k8s resource kind that this fabric supports
+// Kind returns a k8s resource kind that this fabric supports
 func (flowTemplateFactory) Kind() string {
 	return "flow"
 }
 
-// New returns a new object wrapped as Resource
+// New returns Flow controller for new resource based on resource definition
 func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	newFlow := parametrizeResource(def.Flow, gc, "*").(*client.Flow)
 
@@ -68,13 +68,14 @@ func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface
 		}}
 }
 
-// NewExisting returns a new object based on existing one wrapped as Resource
+// NewExisting returns Flow controller for existing resource by its name. Since flow is not a real k8s resource
+// this case is not possible
 func (flowTemplateFactory) NewExisting(name string, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	log.Fatal("Cannot depend on flow that has no resource definition")
 	return nil
 }
 
-// Identifier of the object
+// Key return Flow identifier
 func (f Flow) Key() string {
 	return "flow/" + f.generatedName
 }
@@ -142,7 +143,7 @@ func (f Flow) Delete() error {
 	return nil
 }
 
-// Current status of the flow deployment
+// Status returns current status of the flow deployment
 func (f Flow) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	graph := f.currentGraph
 	if graph == nil {

--- a/pkg/scheduler/frontend.go
+++ b/pkg/scheduler/frontend.go
@@ -173,3 +173,29 @@ func Deploy(sched interfaces.Scheduler, options interfaces.DependencyGraphOption
 	log.Println("Done")
 	return task, nil
 }
+
+// GetStatus returns deployment status
+func GetStatus(client client.Interface, selector labels.Selector,
+	options interfaces.DependencyGraphOptions) (interfaces.DeploymentStatus, interfaces.DeploymentReport, error) {
+
+	silent := options.Silent
+	if options.FlowName == "" {
+		options.FlowName = interfaces.DefaultFlowName
+	}
+	options.ReplicaCount = 0
+	options.Silent = true
+	options.FixedNumberOfReplicas = false
+	options.MinReplicaCount = 0
+	options.MaxReplicaCount = 0
+
+	if !silent {
+		log.Println("Getting status of flow", options.FlowName)
+	}
+	sched := New(client, selector, 0)
+	graph, err := sched.BuildDependencyGraph(options)
+	if err != nil {
+		return interfaces.Empty, nil, err
+	}
+	status, report := graph.GetStatus()
+	return status, report, nil
+}


### PR DESCRIPTION
1) get-status command was missing ability to specify flow name and
   flow args
2) flow Status() method used to return status based on whether flow
   is running or not rather than on statuses of resources in that flow.
   This didn't work with get-status command which doesn't run anything.
   Now the flow status is obtained from the entire subgraph status
3) Helper method to get deployment status was written that can be used
   from both get-status CLI and e2e tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/242)
<!-- Reviewable:end -->
