### PR TITLE
More places where parameters can be used in resources

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/pkg/labels"
 )
 
-var argRe, _ = regexp.Compile(`\s*(\w+)\W+(.*)`)
+var argRe = regexp.MustCompile(`\s*(\w+)\W+(.*)`)
 
 func run(cmd *cobra.Command, args []string) {
 	concurrency, err := cmd.Flags().GetInt("concurrency")
@@ -146,7 +146,7 @@ func getLabelSelector(cmd *cobra.Command) (string, error) {
 // InitRunCommand returns cobra command for creating AppController graph deployment
 func InitRunCommand() (*cobra.Command, error) {
 	run := &cobra.Command{
-		Use:   "run",
+		Use:   "run [flow-name]",
 		Short: "Create deployment of AppController graph flow",
 		Long:  "Create deployment of AppController graph flow",
 		Run:   run,

--- a/e2e/example_runner.go
+++ b/e2e/example_runner.go
@@ -120,7 +120,7 @@ func (f *ExamplesFramework) VerifyStatus(task string, options interfaces.Depende
 			utils.Logf("STATUS: %s\n", status)
 			return status == interfaces.Finished || status == interfaces.Empty
 		},
-		240*time.Second, 5*time.Second).Should(BeTrue(), strings.Join(depReport.AsText(0), "\n"))
+		300*time.Second, 5*time.Second).Should(BeTrue(), strings.Join(depReport.AsText(0), "\n"))
 }
 
 func (f *ExamplesFramework) CreateRunAndVerify(exampleName string, options interfaces.DependencyGraphOptions) {

--- a/e2e/example_runner.go
+++ b/e2e/example_runner.go
@@ -104,7 +104,7 @@ func (f *ExamplesFramework) handleListCreation(ustList *runtime.UnstructuredList
 	}
 }
 
-func (f *ExamplesFramework) VerifyStatus(task string) {
+func (f *ExamplesFramework) VerifyStatus(task string, options interfaces.DependencyGraphOptions) {
 	var depReport report.DeploymentReport
 	Eventually(
 		func() bool {
@@ -112,7 +112,7 @@ func (f *ExamplesFramework) VerifyStatus(task string) {
 			if err == nil {
 				return false
 			}
-			status, r, err := scheduler.GetStatus(f.Client, nil, interfaces.DependencyGraphOptions{})
+			status, r, err := scheduler.GetStatus(f.Client, nil, options)
 			if err != nil {
 				return false
 			}
@@ -123,11 +123,11 @@ func (f *ExamplesFramework) VerifyStatus(task string) {
 		240*time.Second, 5*time.Second).Should(BeTrue(), strings.Join(depReport.AsText(0), "\n"))
 }
 
-func (f *ExamplesFramework) CreateRunAndVerify(exampleName string) {
+func (f *ExamplesFramework) CreateRunAndVerify(exampleName string, options interfaces.DependencyGraphOptions) {
 	By("Creating example " + exampleName)
 	f.CreateExample(exampleName)
 	By("Running appcontroller scheduler")
-	task := f.Run()
+	task := f.RunWithOptions(options)
 	By("Verifying status of deployment for example " + exampleName)
-	f.VerifyStatus(task)
+	f.VerifyStatus(task, options)
 }

--- a/e2e/example_runner.go
+++ b/e2e/example_runner.go
@@ -112,16 +112,13 @@ func (f *ExamplesFramework) VerifyStatus(task string) {
 			if err == nil {
 				return false
 			}
-			depGraph, err := scheduler.New(f.Client, nil, 0).BuildDependencyGraph(
-				interfaces.DependencyGraphOptions{})
+			status, r, err := scheduler.GetStatus(f.Client, nil, interfaces.DependencyGraphOptions{})
 			if err != nil {
 				return false
 			}
-			var status interfaces.DeploymentStatus
-			status, r := depGraph.GetStatus()
 			depReport = r.(report.DeploymentReport)
 			utils.Logf("STATUS: %s\n", status)
-			return status == interfaces.Finished
+			return status == interfaces.Finished || status == interfaces.Empty
 		},
 		240*time.Second, 5*time.Second).Should(BeTrue(), strings.Join(depReport.AsText(0), "\n"))
 }

--- a/e2e/examples_test.go
+++ b/e2e/examples_test.go
@@ -16,22 +16,25 @@ package integration
 
 import (
 	testutils "github.com/Mirantis/k8s-AppController/e2e/utils"
+	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
+
 	. "github.com/onsi/ginkgo"
 )
 
 var _ = Describe("Examples Suite", func() {
+	options := interfaces.DependencyGraphOptions{ReplicaCount: 1}
 	framework := ExamplesFramework{testutils.NewAppControllerManager()}
 
 	It("Example 'simple' should finish", func() {
-		framework.CreateRunAndVerify("simple")
+		framework.CreateRunAndVerify("simple", options)
 	})
 
 	It("Example 'services' should finish", func() {
-		framework.CreateRunAndVerify("services")
+		framework.CreateRunAndVerify("services", options)
 	})
 
 	It("Example 'extended' should finish", func() {
 		testutils.SkipIf14()
-		framework.CreateRunAndVerify("extended")
+		framework.CreateRunAndVerify("extended", options)
 	})
 })

--- a/e2e/flows_test.go
+++ b/e2e/flows_test.go
@@ -1,0 +1,153 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"strings"
+
+	testutils "github.com/Mirantis/k8s-AppController/e2e/utils"
+	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/pkg/api"
+	v1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var _ = Describe("Flows Suite", func() {
+	framework := FlowFramework{ExamplesFramework{testutils.NewAppControllerManager()}}
+
+	It("Example 'flows' should finish and create one graph replica", func() {
+		framework.CreateRunAndVerify("flows", interfaces.DependencyGraphOptions{MinReplicaCount: 1})
+		Eventually(func() int {
+			return framework.countJobs("a-job-", false)
+		}).Should(Equal(1), "1 a-job* should have been created")
+		Eventually(func() int {
+			return framework.countJobs("b-job-", false)
+		}).Should(Equal(1), "1 a-job* should have been created")
+		Eventually(func() int {
+			return framework.countJobs("test-job", true)
+		}).Should(Equal(1), "1 test-job should have been created")
+		Eventually(func() int {
+			return framework.countPods("a-pod-", false)
+		}).Should(Equal(1), "1 a-pod* should have been created")
+		Eventually(func() int {
+			return framework.countPods("b-pod-", false)
+		}).Should(Equal(1), "1 a-pod* should have been created")
+		Eventually(func() int {
+			return framework.countPods("test-pod", true)
+		}).Should(Equal(1), "1 test-pod should have been created")
+		Eventually(func() int {
+			return framework.countReplicas("test-flow-", false)
+		}).Should(Equal(2), "2 test-flow* replicas should have been created")
+		Eventually(func() int {
+			return framework.countReplicas("DEFAULT", true)
+		}).Should(Equal(1), "1 DEFAULT flow replica should have been created")
+	})
+
+	It("Example 'flows' with replication should finish and create two replicas", func() {
+		framework.CreateRunAndVerify("flows", interfaces.DependencyGraphOptions{ReplicaCount: 2})
+		Eventually(func() int {
+			return framework.countJobs("a-job-", false)
+		}).Should(Equal(2), "1 a-job* should have been created")
+		Eventually(func() int {
+			return framework.countJobs("b-job-", false)
+		}).Should(Equal(2), "1 a-job* should have been created")
+		Eventually(func() int {
+			return framework.countJobs("test-job", true)
+		}).Should(Equal(1), "1 test-job should have been created")
+		Eventually(func() int {
+			return framework.countPods("a-pod-", false)
+		}).Should(Equal(2), "1 a-pod* should have been created")
+		Eventually(func() int {
+			return framework.countPods("b-pod-", false)
+		}).Should(Equal(2), "1 a-pod* should have been created")
+		Eventually(func() int {
+			return framework.countPods("test-pod", true)
+		}).Should(Equal(1), "1 test-pod should have been created")
+		Eventually(func() int {
+			return framework.countReplicas("test-flow-", false)
+		}).Should(Equal(4), "2 test-flow* replicas should have been created")
+		Eventually(func() int {
+			return framework.countReplicas("DEFAULT", true)
+		}).Should(Equal(2), "1 DEFAULT flow replica should have been created")
+	})
+
+	It("Example 'flows' should cleanup after itself", func() {
+		framework.CreateRunAndVerify("flows", interfaces.DependencyGraphOptions{ReplicaCount: 1})
+
+		deleteOptions := interfaces.DependencyGraphOptions{ReplicaCount: 0, FixedNumberOfReplicas: true}
+		By("Running appcontroller scheduler")
+		task := framework.RunWithOptions(deleteOptions)
+		By("Verifying status of deployment")
+		framework.VerifyStatus(task, deleteOptions)
+
+		Eventually(func() int {
+			return framework.countReplicas("", false)
+		}).Should(Equal(0), "0 replicas should remain")
+		Eventually(func() int {
+			return framework.countJobs("", false)
+		}).Should(Equal(0), "0 jobs should remain")
+		Eventually(func() int {
+			return framework.countPods("", false)
+		}).Should(Equal(1), "only AC pod should remain")
+	})
+})
+
+type FlowFramework struct {
+	ExamplesFramework
+}
+
+func (ff FlowFramework) countPods(prefix string, equal bool) int {
+	pods, err := ff.Client.Pods().List(v1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	count := 0
+	for _, item := range pods.Items {
+		if item.Status.Phase == v1.PodSucceeded {
+			continue
+		}
+		if equal && item.Name == prefix ||
+			!equal && strings.HasPrefix(item.Name, prefix) && len(item.Name) > len(prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+func (ff FlowFramework) countJobs(prefix string, equal bool) int {
+	jobs, err := ff.Client.Jobs().List(v1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	count := 0
+	for _, item := range jobs.Items {
+		if equal && item.Name == prefix ||
+			!equal && strings.HasPrefix(item.Name, prefix) && len(item.Name) > len(prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+func (ff FlowFramework) countReplicas(prefix string, equal bool) int {
+	jobs, err := ff.Client.Replicas().List(api.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	count := 0
+	for _, item := range jobs.Items {
+		if equal && item.ReplicaSpace == prefix ||
+			!equal && strings.HasPrefix(item.ReplicaSpace, prefix) && len(item.ReplicaSpace) > len(prefix) {
+			count++
+		}
+	}
+	return count
+}

--- a/examples/flows/create.sh
+++ b/examples/flows/create.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source ../common.sh
+
+set -x
+
+$KUBECTL_NAME create -f ../../manifests/appcontroller.yaml
+wait-appcontroller
+
+$KUBECTL_NAME create -f deps.yaml
+
+cat flow.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat job.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat job2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
+
+$KUBECTL_NAME exec k8s-appcontroller run
+
+$KUBECTL_NAME logs -f k8s-appcontroller

--- a/examples/flows/deps.yaml
+++ b/examples/flows/deps.yaml
@@ -1,0 +1,49 @@
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+parent: flow/DEFAULT
+child: flow/test-flow
+args:
+  prefix: a
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+parent: flow/DEFAULT
+child: pod/test-pod
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+parent: pod/test-pod
+child: flow/test-flow
+args:
+  prefix: b
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+parent: flow/test-flow
+child: job/test-job
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: test
+parent: flow/test-flow
+child: pod/$prefix-pod-$AC_NAME
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: test
+parent: pod/$prefix-pod-$AC_NAME
+child: job/$prefix-job-$AC_NAME

--- a/examples/flows/flow.yaml
+++ b/examples/flows/flow.yaml
@@ -1,0 +1,13 @@
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Flow
+metadata:
+  name: test-flow
+
+exported: true
+construction:
+  flow: test
+
+parameters:
+  prefix:
+    description: flow resources prefix
+

--- a/examples/flows/job.yaml
+++ b/examples/flows/job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-job
+spec:
+  template:
+    metadata:
+      name: test-job
+    spec:
+      containers:
+      - name: test-container
+        image: gcr.io/google_containers/busybox
+        command: [ "/bin/sh", "-c", "sleep 10; env"]
+      restartPolicy: Never

--- a/examples/flows/job2.yaml
+++ b/examples/flows/job2.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: $prefix-job-$AC_NAME
+spec:
+  template:
+    metadata:
+      name: test-job2
+    spec:
+      containers:
+      - name: test-container
+        image: gcr.io/google_containers/busybox
+        command: [ "/bin/sh", "-c", "sleep 20; env"]
+      restartPolicy: Never

--- a/examples/flows/pod.yaml
+++ b/examples/flows/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - command: ["/bin/sh"]
+    args:
+    - -c
+    - sleep 2; echo ok > /tmp/health; sleep 600
+    image: gcr.io/google_containers/busybox
+    readinessProbe:
+      exec:
+        command:
+        - /bin/cat
+        - /tmp/health
+    name: test-container

--- a/examples/flows/pod2.yaml
+++ b/examples/flows/pod2.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $prefix-pod-$AC_NAME
+spec:
+  containers:
+  - command: ["/bin/sh"]
+    args:
+    - -c
+    - sleep 3; echo ok > /tmp/health; sleep 600
+    image: gcr.io/google_containers/busybox
+    readinessProbe:
+      exec:
+        command:
+        - /bin/cat
+        - /tmp/health
+    name: test-container

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -203,7 +203,6 @@ func (c Client) IsEnabled(version unversioned.GroupVersion) bool {
 		}
 		for _, v := range group.Versions {
 			if v.Version == version.Version {
-				log.Printf("Found version %v and group %v", group.Name, v.Version)
 				return true
 			}
 		}

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -206,7 +206,7 @@ func GetStringMeta(r interfaces.BaseResource, paramName string, defaultValue str
 }
 
 // Substitutes flow arguments into resource structure. Returns modified copy of the resource
-func parametrizeResource(resource interface{}, context interfaces.GraphContext, replaceIn ...string) interface{} {
+func parametrizeResource(resource interface{}, context interfaces.GraphContext, replaceIn []string) interface{} {
 	return copier.CopyWithReplacements(resource, func(p string) string {
 		value := context.GetArg(p)
 		if value == "" {

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -154,7 +154,7 @@ func podsStateFromLabels(apiClient client.Interface, objLabels map[string]string
 	resources := make([]interfaces.BaseResource, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		p := pod
-		resources = append(resources, NewPod(&p, apiClient.Pods(), nil))
+		resources = append(resources, newPod(&p, apiClient.Pods(), nil))
 	}
 
 	status, err := resourceListStatus(resources)

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -88,7 +88,6 @@ func getKeys(m map[string]interfaces.ResourceTemplate) (keys []string) {
 
 func resourceListStatus(resources []interfaces.BaseResource) (interfaces.ResourceStatus, error) {
 	for _, r := range resources {
-		log.Printf("Checking status for resource %s", r.Key())
 		status, err := r.Status(nil)
 		if err != nil {
 			return interfaces.ResourceError, err

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -39,7 +39,7 @@ type ExistingConfigMap struct {
 
 type configMapTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a configmap
+// ShortName returns wrapped resource name if it was a configmap
 func (configMapTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.ConfigMap == nil {
 		return ""
@@ -47,25 +47,27 @@ func (configMapTemplateFactory) ShortName(definition client.ResourceDefinition) 
 	return definition.ConfigMap.Name
 }
 
-// k8s resource kind that this fabric supports
+// Kind returns a k8s resource kind that this fabric supports
 func (configMapTemplateFactory) Kind() string {
 	return "configmap"
 }
 
-// New returns a new object wrapped as Resource
-func (configMapTemplateFactory) New(def client.ResourceDefinition, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewConfigMap(parametrizeResource(def.ConfigMap, gc).(*v1.ConfigMap), ci.ConfigMaps(), def.Meta)
+// New returns ConfigMap controller for new resource based on resource definition
+func (configMapTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
+	cm := parametrizeResource(def.ConfigMap, gc).(*v1.ConfigMap)
+	return report.SimpleReporter{BaseResource: ConfigMap{Base: Base{def.Meta}, ConfigMap: cm, Client: c.ConfigMaps()}}
 }
 
-// NewExisting returns a new object based on existing one wrapped as Resource
+// NewExisting returns ConfigMap controller for existing resource by its name
 func (configMapTemplateFactory) NewExisting(name string, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return NewExistingConfigMap(name, ci.ConfigMaps())
+	return report.SimpleReporter{BaseResource: ExistingConfigMap{Name: name, Client: ci.ConfigMaps()}}
 }
 
 func configMapKey(name string) string {
 	return "configmap/" + name
 }
 
+// Key returns the ConfigMap object identifier
 func (c ConfigMap) Key() string {
 	return configMapKey(c.ConfigMap.Name)
 }
@@ -84,6 +86,7 @@ func (c ConfigMap) Status(meta map[string]string) (interfaces.ResourceStatus, er
 	return configMapStatus(c.Client, c.ConfigMap.Name)
 }
 
+// Create looks for DaemonSet in k8s and creates it if not present
 func (c ConfigMap) Create() error {
 	if err := checkExistence(c); err != nil {
 		log.Println("Creating", c.Key())
@@ -93,18 +96,12 @@ func (c ConfigMap) Create() error {
 	return nil
 }
 
+// Delete deletes ConfigMap from the cluster
 func (c ConfigMap) Delete() error {
 	return c.Client.Delete(c.ConfigMap.Name, &v1.DeleteOptions{})
 }
 
-func NewConfigMap(c *v1.ConfigMap, client corev1.ConfigMapInterface, meta map[string]interface{}) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ConfigMap{Base: Base{meta}, ConfigMap: c, Client: client}}
-}
-
-func NewExistingConfigMap(name string, client corev1.ConfigMapInterface) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ExistingConfigMap{Name: name, Client: client}}
-}
-
+// Key returns the ConfigMap object identifier
 func (c ExistingConfigMap) Key() string {
 	return configMapKey(c.Name)
 }
@@ -114,10 +111,12 @@ func (c ExistingConfigMap) Status(meta map[string]string) (interfaces.ResourceSt
 	return configMapStatus(c.Client, c.Name)
 }
 
+// Create looks for existing ConfigMap and returns an error if there is no such ConfigMap in a cluster
 func (c ExistingConfigMap) Create() error {
 	return createExistingResource(c)
 }
 
+// Delete deletes ConfigMap from the cluster
 func (c ExistingConfigMap) Delete() error {
 	return c.Client.Delete(c.Name, nil)
 }

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var configMapParamFields = []string{
+	"Data.Keys",
+}
+
 type ConfigMap struct {
 	Base
 	ConfigMap *v1.ConfigMap
@@ -54,7 +58,7 @@ func (configMapTemplateFactory) Kind() string {
 
 // New returns ConfigMap controller for new resource based on resource definition
 func (configMapTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	cm := parametrizeResource(def.ConfigMap, gc).(*v1.ConfigMap)
+	cm := parametrizeResource(def.ConfigMap, gc, configMapParamFields).(*v1.ConfigMap)
 	return report.SimpleReporter{BaseResource: ConfigMap{Base: Base{def.Meta}, ConfigMap: cm, Client: c.ConfigMaps()}}
 }
 

--- a/pkg/resources/daemonset.go
+++ b/pkg/resources/daemonset.go
@@ -26,6 +26,14 @@ import (
 	extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+var daemonSetParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 // DaemonSet is wrapper for K8s DaemonSet object
 type DaemonSet struct {
 	Base
@@ -50,9 +58,7 @@ func (daemonSetTemplateFactory) Kind() string {
 
 // New returns DaemonSets controller for new resource based on resource definition
 func (d daemonSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	newDaemonSet := parametrizeResource(def.DaemonSet, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.DaemonSet)
+	newDaemonSet := parametrizeResource(def.DaemonSet, gc, daemonSetParamFields).(*extbeta1.DaemonSet)
 	return report.SimpleReporter{BaseResource: DaemonSet{Base: Base{def.Meta}, DaemonSet: newDaemonSet, Client: c.DaemonSets()}}
 }
 

--- a/pkg/resources/deployment.go
+++ b/pkg/resources/deployment.go
@@ -26,6 +26,14 @@ import (
 	extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+var deploymentParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 // Deployment is wrapper for K8s Deployment object
 type Deployment struct {
 	Base
@@ -50,9 +58,7 @@ func (deploymentTemplateFactory) Kind() string {
 
 // New returns Deployment controller for new resource based on resource definition
 func (deploymentTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	newDeployment := parametrizeResource(def.Deployment, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.Deployment)
+	newDeployment := parametrizeResource(def.Deployment, gc, deploymentParamFields).(*extbeta1.Deployment)
 	return report.SimpleReporter{BaseResource: Deployment{Base: Base{def.Meta}, Deployment: newDeployment, Client: c.Deployments()}}
 }
 

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -28,9 +28,9 @@ type Flow struct {
 	Base
 	flow          *client.Flow
 	context       interfaces.GraphContext
-	status        interfaces.ResourceStatus
 	generatedName string
 	originalName  string
+	currentGraph  interfaces.DependencyGraph
 }
 
 type flowTemplateFactory struct{}
@@ -63,7 +63,6 @@ func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface
 			Base:          Base{def.Meta},
 			flow:          newFlow,
 			context:       gc,
-			status:        interfaces.ResourceNotReady,
 			generatedName: fmt.Sprintf("%s-%s%s", newFlow.Name, depName, gc.GetArg("AC_NAME")),
 			originalName:  def.Flow.Name,
 		}}
@@ -80,7 +79,7 @@ func (f Flow) Key() string {
 	return "flow/" + f.generatedName
 }
 
-func (f *Flow) buildDependencyGraph(decreaseReplicaCount bool) (interfaces.DependencyGraph, error) {
+func (f *Flow) buildDependencyGraph(replicaCountDelta, minReplicaCount int, silent bool) (interfaces.DependencyGraph, error) {
 	args := map[string]string{}
 	for arg := range f.flow.Parameters {
 		val := f.context.GetArg(arg)
@@ -92,15 +91,9 @@ func (f *Flow) buildDependencyGraph(decreaseReplicaCount bool) (interfaces.Depen
 		FlowName:         f.originalName,
 		Args:             args,
 		FlowInstanceName: f.generatedName,
-	}
-
-	if decreaseReplicaCount {
-		// Delete one replica
-		options.ReplicaCount = -1
-	} else {
-		// Recheck existing replica resources or create one replica if none exist
-		options.ReplicaCount = 0
-		options.MinReplicaCount = 1
+		ReplicaCount:     replicaCountDelta,
+		MinReplicaCount:  minReplicaCount,
+		Silent:           silent,
 	}
 
 	graph, err := f.context.Scheduler().BuildDependencyGraph(options)
@@ -118,14 +111,19 @@ func (f *Flow) buildDependencyGraph(decreaseReplicaCount bool) (interfaces.Depen
 // all subsequent calls will do nothing but check the state of the resources from this replica (and recreate them,
 // if they were deleted manually between the calls), which makes Create() be idempotent
 func (f *Flow) Create() error {
-	graph, err := f.buildDependencyGraph(false)
-	if err != nil {
-		return err
+	graph := f.currentGraph
+
+	if graph == nil {
+		var err error
+		graph, err = f.buildDependencyGraph(0, 1, false)
+		if err != nil {
+			return err
+		}
+		f.currentGraph = graph
 	}
 	go func() {
 		stopChan := make(chan struct{})
 		graph.Deploy(stopChan)
-		f.status = interfaces.ResourceReady
 	}()
 	return nil
 }
@@ -135,17 +133,38 @@ func (f *Flow) Create() error {
 // Delete is called during dlow destruction which can happen only once while Create ensures that at least one flow
 // replica exists, and as such can be called any number of times
 func (f Flow) Delete() error {
-	graph, err := f.buildDependencyGraph(true)
+	graph, err := f.buildDependencyGraph(-1, 0, false)
 	if err != nil {
 		return err
 	}
 	stopChan := make(chan struct{})
 	graph.Deploy(stopChan)
-	f.status = interfaces.ResourceReady
 	return nil
 }
 
 // Current status of the flow deployment
 func (f Flow) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
-	return f.status, nil
+	graph := f.currentGraph
+	if graph == nil {
+		var err error
+		graph, err = f.buildDependencyGraph(0, 0, true)
+		if err != nil {
+			return interfaces.ResourceError, err
+		}
+	}
+
+	status, _ := graph.GetStatus()
+
+	switch status {
+	case interfaces.Empty:
+		fallthrough
+	case interfaces.Finished:
+		return interfaces.ResourceReady, nil
+	case interfaces.Prepared:
+		fallthrough
+	case interfaces.Running:
+		return interfaces.ResourceNotReady, nil
+	default:
+		return interfaces.ResourceError, nil
+	}
 }

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -50,7 +50,7 @@ func (flowTemplateFactory) Kind() string {
 
 // New returns Flow controller for new resource based on resource definition
 func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	newFlow := parametrizeResource(def.Flow, gc, "*").(*client.Flow)
+	newFlow := parametrizeResource(def.Flow, gc, []string{"*"}).(*client.Flow)
 
 	deps := gc.Dependencies()
 	var depName string

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -35,7 +35,7 @@ type Flow struct {
 
 type flowTemplateFactory struct{}
 
-// Returns wrapped resource name if it was a flow
+// ShortName returns wrapped resource name if it was a flow
 func (flowTemplateFactory) ShortName(definition client.ResourceDefinition) string {
 	if definition.Flow == nil {
 		return ""
@@ -43,12 +43,12 @@ func (flowTemplateFactory) ShortName(definition client.ResourceDefinition) strin
 	return definition.Flow.Name
 }
 
-// k8s resource kind that this fabric supports
+// Kind returns a k8s resource kind that this fabric supports
 func (flowTemplateFactory) Kind() string {
 	return "flow"
 }
 
-// New returns a new object wrapped as Resource
+// New returns Flow controller for new resource based on resource definition
 func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	newFlow := parametrizeResource(def.Flow, gc, "*").(*client.Flow)
 
@@ -68,13 +68,14 @@ func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface
 		}}
 }
 
-// NewExisting returns a new object based on existing one wrapped as Resource
+// NewExisting returns Flow controller for existing resource by its name. Since flow is not a real k8s resource
+// this case is not possible
 func (flowTemplateFactory) NewExisting(name string, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	log.Fatal("Cannot depend on flow that has no resource definition")
 	return nil
 }
 
-// Identifier of the object
+// Key return Flow identifier
 func (f Flow) Key() string {
 	return "flow/" + f.generatedName
 }
@@ -142,7 +143,7 @@ func (f Flow) Delete() error {
 	return nil
 }
 
-// Current status of the flow deployment
+// Status returns current status of the flow deployment
 func (f Flow) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	graph := f.currentGraph
 	if graph == nil {

--- a/pkg/resources/job.go
+++ b/pkg/resources/job.go
@@ -25,6 +25,14 @@ import (
 	"k8s.io/client-go/pkg/apis/batch/v1"
 )
 
+var jobParamFields = []string{
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.ObjectMeta",
+}
+
 type Job struct {
 	Base
 	Job    *v1.Job
@@ -52,9 +60,7 @@ func (jobTemplateFactory) Kind() string {
 
 // New returns Job controller for new resource based on resource definition
 func (jobTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	job := parametrizeResource(def.Job, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*v1.Job)
+	job := parametrizeResource(def.Job, gc, jobParamFields).(*v1.Job)
 	return newJob(job, c.Jobs(), def.Meta)
 }
 

--- a/pkg/resources/persistentvolumeclaim.go
+++ b/pkg/resources/persistentvolumeclaim.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var persistentVolumeClaimParamFields = []string{
+	"Spec",
+}
+
 type PersistentVolumeClaim struct {
 	Base
 	PersistentVolumeClaim *v1.PersistentVolumeClaim
@@ -51,7 +55,7 @@ func (persistentVolumeClaimTemplateFactory) New(def client.ResourceDefinition, c
 	return report.SimpleReporter{
 		BaseResource: PersistentVolumeClaim{
 			Base: Base{def.Meta},
-			PersistentVolumeClaim: parametrizeResource(def.PersistentVolumeClaim, gc).(*v1.PersistentVolumeClaim),
+			PersistentVolumeClaim: parametrizeResource(def.PersistentVolumeClaim, gc, persistentVolumeClaimParamFields).(*v1.PersistentVolumeClaim),
 			Client: c.PersistentVolumeClaims(),
 		}}
 }

--- a/pkg/resources/petset.go
+++ b/pkg/resources/petset.go
@@ -24,6 +24,14 @@ import (
 	"github.com/Mirantis/k8s-AppController/pkg/report"
 )
 
+var petSetParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 // PetSet is a wrapper for K8s PetSet object
 type PetSet struct {
 	Base
@@ -49,9 +57,7 @@ func (petSetTemplateFactory) Kind() string {
 
 // New returns PetSet controller for new resource based on resource definition
 func (petSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	petSet := parametrizeResource(def.PetSet, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*appsalpha1.PetSet)
+	petSet := parametrizeResource(def.PetSet, gc, petSetParamFields).(*appsalpha1.PetSet)
 	return newPetSet(petSet, c.PetSets(), c, def.Meta)
 }
 

--- a/pkg/resources/pod.go
+++ b/pkg/resources/pod.go
@@ -25,6 +25,13 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var podParamFields = []string{
+	"Spec.Containers.Env",
+	"Spec.Containers.Name",
+	"Spec.InitContainers.Env",
+	"Spec.InitContainers.Name",
+}
+
 type Pod struct {
 	Base
 	Pod    *v1.Pod
@@ -48,9 +55,7 @@ func (podTemplateFactory) Kind() string {
 
 // New returns Pod controller for new resource based on resource definition
 func (podTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	pod := parametrizeResource(def.Pod, gc,
-		"Spec.Containers.Env",
-		"Spec.InitContainers.Env").(*v1.Pod)
+	pod := parametrizeResource(def.Pod, gc, podParamFields).(*v1.Pod)
 	return newPod(pod, c.Pods(), def.Meta)
 }
 

--- a/pkg/resources/replicaset.go
+++ b/pkg/resources/replicaset.go
@@ -26,6 +26,14 @@ import (
 	extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+var replicaSetParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 const SuccessFactorKey = "success_factor"
 
 type ReplicaSet struct {
@@ -51,9 +59,7 @@ func (replicaSetTemplateFactory) Kind() string {
 
 // New returns ReplicaSet controller for new resource based on resource definition
 func (replicaSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	replicaSet := parametrizeResource(def.ReplicaSet, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.ReplicaSet)
+	replicaSet := parametrizeResource(def.ReplicaSet, gc, replicaSetParamFields).(*extbeta1.ReplicaSet)
 	return newReplicaSet(replicaSet, c.ReplicaSets(), def.Meta)
 }
 

--- a/pkg/resources/secrets.go
+++ b/pkg/resources/secrets.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var secretParamFields = []string{
+	"Data.Keys",
+	"StringData.Keys",
+}
+
 type Secret struct {
 	Base
 	Secret *v1.Secret
@@ -54,7 +59,7 @@ func (secretTemplateFactory) Kind() string {
 
 // New returns Secret controller for new resource based on resource definition
 func (secretTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	secret := parametrizeResource(def.Secret, gc).(*v1.Secret)
+	secret := parametrizeResource(def.Secret, gc, secretParamFields).(*v1.Secret)
 	return report.SimpleReporter{BaseResource: Secret{Base: Base{def.Meta}, Secret: secret, Client: c.Secrets()}}
 }
 

--- a/pkg/resources/service.go
+++ b/pkg/resources/service.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/client-go/pkg/labels"
 )
 
+var serviceParamFields = []string{
+	"Spec.Selector",
+}
+
 type Service struct {
 	Base
 	Service   *v1.Service
@@ -53,7 +57,7 @@ func (serviceTemplateFactory) Kind() string {
 
 // New returns Service controller for new resource based on resource definition
 func (serviceTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	service := parametrizeResource(def.Service, gc).(*v1.Service)
+	service := parametrizeResource(def.Service, gc, serviceParamFields).(*v1.Service)
 	return report.SimpleReporter{BaseResource: Service{Base: Base{def.Meta}, Service: service, Client: c.Services(), APIClient: c}}
 }
 

--- a/pkg/resources/serviceaccount.go
+++ b/pkg/resources/serviceaccount.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var serviceAccountParamFields = []string{
+	"Secrets",
+	"ImagePullSecrets",
+}
+
 type ServiceAccount struct {
 	Base
 	ServiceAccount *v1.ServiceAccount
@@ -54,7 +59,7 @@ func (serviceAccountTemplateFactory) Kind() string {
 
 // New returns ServiceAccount controller for new resource based on resource definition
 func (serviceAccountTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	serviceAccount := parametrizeResource(def.ServiceAccount, gc).(*v1.ServiceAccount)
+	serviceAccount := parametrizeResource(def.ServiceAccount, gc, serviceAccountParamFields).(*v1.ServiceAccount)
 	return report.SimpleReporter{
 		BaseResource: ServiceAccount{Base: Base{def.Meta}, ServiceAccount: serviceAccount, Client: c.ServiceAccounts()},
 	}

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -25,6 +25,14 @@ import (
 	appsbeta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
 )
 
+var statefulSetParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 // StatefulSet is a wrapper for K8s StatefulSet object
 type StatefulSet struct {
 	Base
@@ -50,9 +58,7 @@ func (statefulSetTemplateFactory) Kind() string {
 
 // New returns StatefulSet controller for new resource based on resource definition
 func (statefulSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	statefulSet := parametrizeResource(def.StatefulSet, gc,
-	"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*appsbeta1.StatefulSet)
+	statefulSet := parametrizeResource(def.StatefulSet, gc, statefulSetParamFields).(*appsbeta1.StatefulSet)
 	return newStatefulSet(statefulSet, c.StatefulSets(), c, def.Meta)
 }
 

--- a/pkg/scheduler/dependency_graph_test.go
+++ b/pkg/scheduler/dependency_graph_test.go
@@ -28,7 +28,8 @@ func TestAllocateReplicas(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
 	sched := New(c, nil, 0).(*Scheduler)
-	newReplicas1, deleteReplicas, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: 3})
+	newReplicas1, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +42,8 @@ func TestAllocateReplicas(t *testing.T) {
 	}
 	ensureReplicas(c, t, 0, 3)
 
-	newReplicas2, deleteReplicas, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: 1})
+	newReplicas2, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 1}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,10 +56,8 @@ func TestAllocateReplicas(t *testing.T) {
 	}
 	ensureReplicas(c, t, 0, 4)
 
-	allReplicas, deleteReplicas, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{
-		ReplicaCount:          5,
-		FixedNumberOfReplicas: true,
-	})
+	allReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 5, FixedNumberOfReplicas: true}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,8 @@ func TestAllocateReplicas(t *testing.T) {
 		t.Error("replica list is not stable")
 	}
 
-	allReplicas2, deleteReplicas, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: 0})
+	allReplicas2, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 0}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +98,8 @@ func TestDeallocateReplicas(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
 	sched := New(c, nil, 0).(*Scheduler)
-	newReplicas1, deleteReplicas1, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: 5})
+	newReplicas1, deleteReplicas1, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 5}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +112,8 @@ func TestDeallocateReplicas(t *testing.T) {
 	}
 	ensureReplicas(c, t, 0, 5)
 
-	newReplicas2, deleteReplicas2, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: -2})
+	newReplicas2, deleteReplicas2, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: -2}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,13 +134,17 @@ func TestDeallocateReplicas(t *testing.T) {
 	ensureReplicas(c, t, 0, 5)
 }
 
+func toContext(options interfaces.DependencyGraphOptions) *GraphContext {
+	return &GraphContext{graph: &DependencyGraph{graphOptions: options}}
+}
+
 // TestAllocateReplicasMinMax tests replica allocation with min/max constraints applied
 func TestAllocateReplicasMinMax(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
 	sched := New(c, nil, 0).(*Scheduler)
 	newReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
-		interfaces.DependencyGraphOptions{ReplicaCount: 3, MinReplicaCount: 5, MaxReplicaCount: 10})
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3, MinReplicaCount: 5, MaxReplicaCount: 10}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +158,7 @@ func TestAllocateReplicasMinMax(t *testing.T) {
 	ensureReplicas(c, t, 0, 5)
 
 	newReplicas, deleteReplicas, _ = sched.allocateReplicas(flow,
-		interfaces.DependencyGraphOptions{ReplicaCount: 9, MinReplicaCount: 5, MaxReplicaCount: 10})
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 9, MinReplicaCount: 5, MaxReplicaCount: 10}))
 
 	if len(newReplicas) != 5 {
 		t.Fatal("unexpected new replica count", len(newReplicas))
@@ -162,7 +169,7 @@ func TestAllocateReplicasMinMax(t *testing.T) {
 	ensureReplicas(c, t, 0, 10)
 
 	newReplicas, deleteReplicas, err = sched.allocateReplicas(flow,
-		interfaces.DependencyGraphOptions{ReplicaCount: -6, MinReplicaCount: 5, MaxReplicaCount: 10})
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: -6, MinReplicaCount: 5, MaxReplicaCount: 10}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/scheduler/frontend.go
+++ b/pkg/scheduler/frontend.go
@@ -34,6 +34,9 @@ type Scheduler struct {
 
 // New creates and initializes instance of Scheduler
 func New(client client.Interface, selector labels.Selector, concurrency int) interfaces.Scheduler {
+	if selector == nil {
+		selector, _ = labels.Parse("")
+	}
 	return &Scheduler{
 		client:      client,
 		selector:    selector,
@@ -146,6 +149,9 @@ func (sched *Scheduler) CreateDeployment(options interfaces.DependencyGraphOptio
 
 // Deploy deploys the dependency graph either in-place or by creating deployment task for a standalone process
 func Deploy(sched interfaces.Scheduler, options interfaces.DependencyGraphOptions, inplace bool, stopChan <-chan struct{}) (string, error) {
+	if options.FlowName == "" {
+		options.FlowName = interfaces.DefaultFlowName
+	}
 	var task string
 	if inplace {
 		log.Println("Going to deploy flow:", options.FlowName)

--- a/pkg/scheduler/frontend.go
+++ b/pkg/scheduler/frontend.go
@@ -173,3 +173,29 @@ func Deploy(sched interfaces.Scheduler, options interfaces.DependencyGraphOption
 	log.Println("Done")
 	return task, nil
 }
+
+// GetStatus returns deployment status
+func GetStatus(client client.Interface, selector labels.Selector,
+	options interfaces.DependencyGraphOptions) (interfaces.DeploymentStatus, interfaces.DeploymentReport, error) {
+
+	silent := options.Silent
+	if options.FlowName == "" {
+		options.FlowName = interfaces.DefaultFlowName
+	}
+	options.ReplicaCount = 0
+	options.Silent = true
+	options.FixedNumberOfReplicas = false
+	options.MinReplicaCount = 0
+	options.MaxReplicaCount = 0
+
+	if !silent {
+		log.Println("Getting status of flow", options.FlowName)
+	}
+	sched := New(client, selector, 0)
+	graph, err := sched.BuildDependencyGraph(options)
+	if err != nil {
+		return interfaces.Empty, nil, err
+	}
+	status, report := graph.GetStatus()
+	return status, report, nil
+}


### PR DESCRIPTION
1) Refactoring: separate specification of list of fields where
   parameter substitution is allowed for each resource
2) More fields can be parametrized. Most notable are names of containers
3) When depending on existing (external) resource by its name, this name
   can also be parametrized
4) Ability to specify Map.Keys/Map.Values field names for maps so that
   substitution take place only in map keys or values

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/245)
<!-- Reviewable:end -->
