### PR TITLE
Do not check service-dependent resource status by selector parts

### DIFF
--- a/examples/etcd/Dockerfile
+++ b/examples/etcd/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/google_containers/etcd-amd64:2.2.5
+
+ADD kubectl /usr/local/bin

--- a/examples/etcd/README.md
+++ b/examples/etcd/README.md
@@ -1,0 +1,30 @@
+etcd cluster application
+------------------------
+
+1. Prepare AppController:
+
+    1. Start AppController Pod. Suppose its name is k8s-appcontroller
+    2. Upload etcd graph definition resources to k8s by running create.sh.
+       This script uploads two AppController flows: `etcd-bootstrap` and `etcd-scale`.
+    3. This application uses custom etcd docker image which is the original etcd image plus kubectl binary.
+       Use build-image.sh script to build the image `etcd-kubectl` and then publish it to the docker repository
+       used by your k8s environment. 
+
+2. Deploy the cluster:
+
+`kubectl exec k8s-appcontroller kubeac run etcd-bootstrap -n 3 --arg clusterName=my-cluster`
+
+`-n 3` - initial number of etcd nodes (can be any number)
+
+`--arg clusterName=my-cluster` - cluster name. This allows to deploy several independent cluster in one k8s namespace. 
+If omitted, `etcd` name is used by default.
+
+3. Scale the cluster:
+
+`kubectl exec k8s-appcontroller kubeac run etcd-scale -n +1 --arg clusterName=my-cluster`
+
+`-n +1` - adds one node to the cluster. Use `-n -1` to scale the cluster down by one node. In this case the last 
+added node is going to be deleted. At the moment it is only possible to scale cluster up by one node at a time. 
+However, any number of nodes can be removed. Note, that this can also remove nodes created upon initial deployment. 
+
+`--arg clusterName=my-cluster` - name of the cluster to scale (`etcd` if not specified).

--- a/examples/etcd/build-image.sh
+++ b/examples/etcd/build-image.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+docker build . -t etcd-kubectl

--- a/examples/etcd/create.sh
+++ b/examples/etcd/create.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source ../common.sh
+
+set -x
+
+AC_POD_NAME=${AC_POD_NAME:-k8s-appcontroller}
+
+for file in resdefs/*.yaml
+do 
+  cat $file | $KUBECTL_NAME exec -i $AC_POD_NAME kubeac wrap | $KUBECTL_NAME create -f-
+done
+
+for file in dependencies/*.yaml
+do 
+  cat $file | $KUBECTL_NAME create -f-
+done

--- a/examples/etcd/dependencies/etcd-bootstrap.yaml
+++ b/examples/etcd/dependencies/etcd-bootstrap.yaml
@@ -1,0 +1,35 @@
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: etcd-bootstrap
+parent: flow/etcd-bootstrap
+child: service/etcd-$AC_NAME
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: etcd-bootstrap
+parent: service/etcd-$AC_NAME
+child: service/$clusterName-client
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: etcd-bootstrap
+parent: service/$clusterName-client
+child: pod/initial-etcd-pod-$AC_NAME
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: cleanup
+parent: flow/etcd-bootstrap
+child: job/delete-node-$AC_NAME-job

--- a/examples/etcd/dependencies/etcd-scale.yaml
+++ b/examples/etcd/dependencies/etcd-scale.yaml
@@ -1,0 +1,36 @@
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: etcd-scale
+parent: flow/etcd-scale
+child: job/add-etcd-node-$AC_NAME-job
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: etcd-scale
+parent: job/add-etcd-node-$AC_NAME-job
+child: service/etcd-$AC_NAME
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: etcd-scale
+parent: service/etcd-$AC_NAME
+child: pod/etcd-pod-$AC_NAME
+---
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Dependency
+metadata:
+  generateName: dependency-
+  labels:
+    flow: cleanup
+parent: flow/etcd-scale
+child: job/delete-node-$AC_NAME-job
+

--- a/examples/etcd/resdefs/add-node-job.yaml
+++ b/examples/etcd/resdefs/add-node-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: add-etcd-node-$AC_NAME-job
+spec:
+  template:
+    metadata:
+      name: add-etcd-node-$AC_NAME-job
+    spec:
+      containers:
+      - name: add-etcd-node-$AC_NAME
+        image: etcd-kubectl
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: HOSTNAME
+            value: etcd-$AC_NAME
+          - name: CLUSTERNAME
+            value: $clusterName
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - "-x"
+          - |
+            # register new node.
+            # This sets ETCD_NAME, ETCD_INITIAL_CLUSTER and ETCD_INITIAL_CLUSTER_STATE variables
+            eval $(etcdctl --endpoint "http://$CLUSTERNAME-client:2379" member add $HOSTNAME "http://$HOSTNAME:2380" | grep "^ETCD_")
+            # store them in ConfigMap
+            kubectl create configmap "etcd-node-$HOSTNAME" \
+              --from-literal=ETCD_NAME="$ETCD_NAME" \
+              --from-literal=ETCD_INITIAL_CLUSTER="$ETCD_INITIAL_CLUSTER" \
+              --from-literal=ETCD_INITIAL_CLUSTER_STATE="$ETCD_INITIAL_CLUSTER_STATE"
+
+      restartPolicy: Never

--- a/examples/etcd/resdefs/bootstrap-flow.yaml
+++ b/examples/etcd/resdefs/bootstrap-flow.yaml
@@ -1,0 +1,17 @@
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Flow
+metadata:
+  name: etcd-bootstrap
+
+exported: true
+construction:
+  flow: etcd-bootstrap
+destruction:
+  flow: cleanup
+
+replicaSpace: etcd-$clusterName-node
+
+parameters:
+  clusterName:
+    description: etcd cluster name
+    default: etcd

--- a/examples/etcd/resdefs/delete-node-job.yaml
+++ b/examples/etcd/resdefs/delete-node-job.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-node-$AC_NAME-job
+spec:
+  template:
+    metadata:
+      name: delete-node-$AC_NAME-job
+    spec:
+      containers:
+      - name: delete-node-$AC_NAME
+        image: etcd-kubectl
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: MEMBER_NAME
+            value: etcd-$AC_NAME
+          - name: CLUSTERNAME
+            value: $clusterName
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            # find member ID by the name
+            MEMBER_ID=$(etcdctl --endpoint "http://$CLUSTERNAME-client:2379" member list | grep name="$MEMBER_NAME" | cut -d':' -f1)
+            # remove member
+            etcdctl --endpoint "http://$CLUSTERNAME-client:2379" member remove "$MEMBER_ID"
+      restartPolicy: Never

--- a/examples/etcd/resdefs/etcd-pod.yaml
+++ b/examples/etcd/resdefs/etcd-pod.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-pod-$AC_NAME
+  labels:
+    app: etcd
+    etcd_node: etcd-$AC_NAME
+    cluster: $clusterName
+spec:
+  containers:
+  - image: etcd-kubectl
+    imagePullPolicy: IfNotPresent
+    name: etcd-$AC_NAME
+    env:
+      - name: HOSTNAME
+        value: etcd-$AC_NAME
+      - name: ETCD_NAME
+        valueFrom:
+          configMapKeyRef:
+            name: etcd-node-etcd-$AC_NAME
+            key: ETCD_NAME
+      - name: ETCD_INITIAL_CLUSTER
+        valueFrom:
+          configMapKeyRef:
+            name: etcd-node-etcd-$AC_NAME
+            key: ETCD_INITIAL_CLUSTER
+      - name: ETCD_INITIAL_CLUSTER_STATE
+        valueFrom:
+          configMapKeyRef:
+            name: etcd-node-etcd-$AC_NAME
+            key: ETCD_INITIAL_CLUSTER_STATE
+    command:
+    - "/bin/sh"
+    - "-ec"
+    - |
+      kubectl delete cm "etcd-node-$HOSTNAME"
+      exec etcd --initial-advertise-peer-urls "http://$HOSTNAME:2380" \
+           --listen-peer-urls http://0.0.0.0:2380 \
+           --listen-client-urls http://0.0.0.0:2379 \
+           --advertise-client-urls "http://$HOSTNAME:2379"
+    ports:
+    - containerPort: 2379
+      name: client
+      protocol: TCP
+    - containerPort: 2380
+      name: server
+      protocol: TCP
+  restartPolicy: Never

--- a/examples/etcd/resdefs/initial-pod.yaml
+++ b/examples/etcd/resdefs/initial-pod.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: initial-etcd-pod-$AC_NAME
+  labels:
+    app: etcd
+    etcd_node: etcd-$AC_NAME
+    cluster: $clusterName
+spec:
+  containers:
+  - image: etcd-kubectl
+    imagePullPolicy: IfNotPresent
+    name: etcd-$AC_NAME
+    env:
+    - name: HOSTNAME
+      value: etcd-$AC_NAME
+    - name: CLUSTERNAME
+      value: $clusterName
+    command:
+    - "/bin/sh"
+    - "-ec"
+    - |
+      INITIAL_CLUSTER=$(kubectl get services -l=app=etcd,serviceRole=node,cluster="$CLUSTERNAME" --template \
+         '{{range .items}}{{.metadata.name}}=http://{{.metadata.name}}{{":2380\n"}}{{end}}' | awk -F'\n' '{if(NR == 1) {printf $0} else {printf ","$0}}')
+      exec etcd --name $HOSTNAME \
+        --initial-advertise-peer-urls "http://$HOSTNAME:2380" \
+        --listen-peer-urls http://0.0.0.0:2380 \
+        --listen-client-urls http://0.0.0.0:2379 \
+        --advertise-client-urls "http://$HOSTNAME:2379" \
+        --initial-cluster "$INITIAL_CLUSTER" \
+        --initial-cluster-state new
+    ports:
+    - containerPort: 2379
+      name: client
+      protocol: TCP
+    - containerPort: 2380
+      name: server
+      protocol: TCP
+  restartPolicy: Never

--- a/examples/etcd/resdefs/node-service.yaml
+++ b/examples/etcd/resdefs/node-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: etcd
+    etcd_node: etcd-$AC_NAME
+    cluster: $clusterName
+    serviceRole: node
+  name: etcd-$AC_NAME
+spec:
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: server
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    app: etcd
+    etcd_node: etcd-$AC_NAME
+    cluster: $clusterName

--- a/examples/etcd/resdefs/scale-flow.yaml
+++ b/examples/etcd/resdefs/scale-flow.yaml
@@ -1,0 +1,17 @@
+apiVersion: appcontroller.k8s/v1alpha1
+kind: Flow
+metadata:
+  name: etcd-scale
+
+exported: true
+construction:
+  flow: etcd-scale
+destruction:
+  flow: cleanup
+
+replicaSpace: etcd-$clusterName-node
+
+parameters:
+  clusterName:
+    description: etcd cluster name
+    default: etcd

--- a/examples/etcd/resdefs/service.yaml
+++ b/examples/etcd/resdefs/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: etcd
+    cluster: $clusterName
+    serviceRole: cluster
+  name: $clusterName-client
+spec:
+  ports:
+  - name: etcd-client-port
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  selector:
+    app: etcd
+    cluster: $clusterName
+

--- a/pkg/mocks/replicasets.go
+++ b/pkg/mocks/replicasets.go
@@ -14,14 +14,20 @@
 
 package mocks
 
-import extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+import (
+	"strings"
+
+	extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
 
 func MakeReplicaSet(name string) *extbeta1.ReplicaSet {
+	status := strings.Split(name, "-")[0]
+
 	replicaSet := &extbeta1.ReplicaSet{}
 	replicaSet.Name = name
 	replicaSet.Namespace = "testing"
 	replicaSet.Spec.Replicas = pointer(int32(2))
-	if name != "fail" {
+	if status != "fail" {
 		replicaSet.Status.Replicas = int32(3)
 	}
 

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -206,7 +206,7 @@ func GetStringMeta(r interfaces.BaseResource, paramName string, defaultValue str
 }
 
 // Substitutes flow arguments into resource structure. Returns modified copy of the resource
-func parametrizeResource(resource interface{}, context interfaces.GraphContext, replaceIn ...string) interface{} {
+func parametrizeResource(resource interface{}, context interfaces.GraphContext, replaceIn []string) interface{} {
 	return copier.CopyWithReplacements(resource, func(p string) string {
 		value := context.GetArg(p)
 		if value == "" {

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var configMapParamFields = []string{
+	"Data.Keys",
+}
+
 type ConfigMap struct {
 	Base
 	ConfigMap *v1.ConfigMap
@@ -54,7 +58,7 @@ func (configMapTemplateFactory) Kind() string {
 
 // New returns ConfigMap controller for new resource based on resource definition
 func (configMapTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	cm := parametrizeResource(def.ConfigMap, gc).(*v1.ConfigMap)
+	cm := parametrizeResource(def.ConfigMap, gc, configMapParamFields).(*v1.ConfigMap)
 	return report.SimpleReporter{BaseResource: ConfigMap{Base: Base{def.Meta}, ConfigMap: cm, Client: c.ConfigMaps()}}
 }
 

--- a/pkg/resources/daemonset.go
+++ b/pkg/resources/daemonset.go
@@ -26,6 +26,14 @@ import (
 	extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+var daemonSetParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 // DaemonSet is wrapper for K8s DaemonSet object
 type DaemonSet struct {
 	Base
@@ -50,9 +58,7 @@ func (daemonSetTemplateFactory) Kind() string {
 
 // New returns DaemonSets controller for new resource based on resource definition
 func (d daemonSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	newDaemonSet := parametrizeResource(def.DaemonSet, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.DaemonSet)
+	newDaemonSet := parametrizeResource(def.DaemonSet, gc, daemonSetParamFields).(*extbeta1.DaemonSet)
 	return report.SimpleReporter{BaseResource: DaemonSet{Base: Base{def.Meta}, DaemonSet: newDaemonSet, Client: c.DaemonSets()}}
 }
 

--- a/pkg/resources/deployment.go
+++ b/pkg/resources/deployment.go
@@ -26,6 +26,14 @@ import (
 	extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+var deploymentParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 // Deployment is wrapper for K8s Deployment object
 type Deployment struct {
 	Base
@@ -50,9 +58,7 @@ func (deploymentTemplateFactory) Kind() string {
 
 // New returns Deployment controller for new resource based on resource definition
 func (deploymentTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	newDeployment := parametrizeResource(def.Deployment, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.Deployment)
+	newDeployment := parametrizeResource(def.Deployment, gc, deploymentParamFields).(*extbeta1.Deployment)
 	return report.SimpleReporter{BaseResource: Deployment{Base: Base{def.Meta}, Deployment: newDeployment, Client: c.Deployments()}}
 }
 

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -50,7 +50,7 @@ func (flowTemplateFactory) Kind() string {
 
 // New returns Flow controller for new resource based on resource definition
 func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	newFlow := parametrizeResource(def.Flow, gc, "*").(*client.Flow)
+	newFlow := parametrizeResource(def.Flow, gc, []string{"*"}).(*client.Flow)
 
 	deps := gc.Dependencies()
 	var depName string

--- a/pkg/resources/job.go
+++ b/pkg/resources/job.go
@@ -25,6 +25,14 @@ import (
 	"k8s.io/client-go/pkg/apis/batch/v1"
 )
 
+var jobParamFields = []string{
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.ObjectMeta",
+}
+
 type Job struct {
 	Base
 	Job    *v1.Job
@@ -52,9 +60,7 @@ func (jobTemplateFactory) Kind() string {
 
 // New returns Job controller for new resource based on resource definition
 func (jobTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	job := parametrizeResource(def.Job, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*v1.Job)
+	job := parametrizeResource(def.Job, gc, jobParamFields).(*v1.Job)
 	return newJob(job, c.Jobs(), def.Meta)
 }
 

--- a/pkg/resources/persistentvolumeclaim.go
+++ b/pkg/resources/persistentvolumeclaim.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var persistentVolumeClaimParamFields = []string{
+	"Spec",
+}
+
 type PersistentVolumeClaim struct {
 	Base
 	PersistentVolumeClaim *v1.PersistentVolumeClaim
@@ -51,7 +55,7 @@ func (persistentVolumeClaimTemplateFactory) New(def client.ResourceDefinition, c
 	return report.SimpleReporter{
 		BaseResource: PersistentVolumeClaim{
 			Base: Base{def.Meta},
-			PersistentVolumeClaim: parametrizeResource(def.PersistentVolumeClaim, gc).(*v1.PersistentVolumeClaim),
+			PersistentVolumeClaim: parametrizeResource(def.PersistentVolumeClaim, gc, persistentVolumeClaimParamFields).(*v1.PersistentVolumeClaim),
 			Client: c.PersistentVolumeClaims(),
 		}}
 }

--- a/pkg/resources/petset.go
+++ b/pkg/resources/petset.go
@@ -24,6 +24,14 @@ import (
 	"github.com/Mirantis/k8s-AppController/pkg/report"
 )
 
+var petSetParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 // PetSet is a wrapper for K8s PetSet object
 type PetSet struct {
 	Base
@@ -49,9 +57,7 @@ func (petSetTemplateFactory) Kind() string {
 
 // New returns PetSet controller for new resource based on resource definition
 func (petSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	petSet := parametrizeResource(def.PetSet, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*appsalpha1.PetSet)
+	petSet := parametrizeResource(def.PetSet, gc, petSetParamFields).(*appsalpha1.PetSet)
 	return newPetSet(petSet, c.PetSets(), c, def.Meta)
 }
 

--- a/pkg/resources/pod.go
+++ b/pkg/resources/pod.go
@@ -25,6 +25,13 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var podParamFields = []string{
+	"Spec.Containers.Env",
+	"Spec.Containers.Name",
+	"Spec.InitContainers.Env",
+	"Spec.InitContainers.Name",
+}
+
 type Pod struct {
 	Base
 	Pod    *v1.Pod
@@ -48,9 +55,7 @@ func (podTemplateFactory) Kind() string {
 
 // New returns Pod controller for new resource based on resource definition
 func (podTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	pod := parametrizeResource(def.Pod, gc,
-		"Spec.Containers.Env",
-		"Spec.InitContainers.Env").(*v1.Pod)
+	pod := parametrizeResource(def.Pod, gc, podParamFields).(*v1.Pod)
 	return newPod(pod, c.Pods(), def.Meta)
 }
 

--- a/pkg/resources/replicaset.go
+++ b/pkg/resources/replicaset.go
@@ -26,6 +26,14 @@ import (
 	extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+var replicaSetParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 const SuccessFactorKey = "success_factor"
 
 type ReplicaSet struct {
@@ -51,9 +59,7 @@ func (replicaSetTemplateFactory) Kind() string {
 
 // New returns ReplicaSet controller for new resource based on resource definition
 func (replicaSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	replicaSet := parametrizeResource(def.ReplicaSet, gc,
-		"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*extbeta1.ReplicaSet)
+	replicaSet := parametrizeResource(def.ReplicaSet, gc, replicaSetParamFields).(*extbeta1.ReplicaSet)
 	return newReplicaSet(replicaSet, c.ReplicaSets(), def.Meta)
 }
 

--- a/pkg/resources/secrets.go
+++ b/pkg/resources/secrets.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var secretParamFields = []string{
+	"Data.Keys",
+	"StringData.Keys",
+}
+
 type Secret struct {
 	Base
 	Secret *v1.Secret
@@ -54,7 +59,7 @@ func (secretTemplateFactory) Kind() string {
 
 // New returns Secret controller for new resource based on resource definition
 func (secretTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	secret := parametrizeResource(def.Secret, gc).(*v1.Secret)
+	secret := parametrizeResource(def.Secret, gc, secretParamFields).(*v1.Secret)
 	return report.SimpleReporter{BaseResource: Secret{Base: Base{def.Meta}, Secret: secret, Client: c.Secrets()}}
 }
 

--- a/pkg/resources/service.go
+++ b/pkg/resources/service.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/client-go/pkg/labels"
 )
 
+var serviceParamFields = []string{
+	"Spec.Selector",
+}
+
 type Service struct {
 	Base
 	Service   *v1.Service
@@ -53,7 +57,7 @@ func (serviceTemplateFactory) Kind() string {
 
 // New returns Service controller for new resource based on resource definition
 func (serviceTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	service := parametrizeResource(def.Service, gc).(*v1.Service)
+	service := parametrizeResource(def.Service, gc, serviceParamFields).(*v1.Service)
 	return report.SimpleReporter{BaseResource: Service{Base: Base{def.Meta}, Service: service, Client: c.Services(), APIClient: c}}
 }
 

--- a/pkg/resources/serviceaccount.go
+++ b/pkg/resources/serviceaccount.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+var serviceAccountParamFields = []string{
+	"Secrets",
+	"ImagePullSecrets",
+}
+
 type ServiceAccount struct {
 	Base
 	ServiceAccount *v1.ServiceAccount
@@ -54,7 +59,7 @@ func (serviceAccountTemplateFactory) Kind() string {
 
 // New returns ServiceAccount controller for new resource based on resource definition
 func (serviceAccountTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	serviceAccount := parametrizeResource(def.ServiceAccount, gc).(*v1.ServiceAccount)
+	serviceAccount := parametrizeResource(def.ServiceAccount, gc, serviceAccountParamFields).(*v1.ServiceAccount)
 	return report.SimpleReporter{
 		BaseResource: ServiceAccount{Base: Base{def.Meta}, ServiceAccount: serviceAccount, Client: c.ServiceAccounts()},
 	}

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -25,6 +25,14 @@ import (
 	appsbeta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
 )
 
+var statefulSetParamFields = []string{
+	"Spec.Template.Spec.Containers.Name",
+	"Spec.Template.Spec.Containers.Env",
+	"Spec.Template.Spec.InitContainers.Name",
+	"Spec.Template.Spec.InitContainers.Env",
+	"Spec.Template.ObjectMeta",
+}
+
 // StatefulSet is a wrapper for K8s StatefulSet object
 type StatefulSet struct {
 	Base
@@ -50,9 +58,7 @@ func (statefulSetTemplateFactory) Kind() string {
 
 // New returns StatefulSet controller for new resource based on resource definition
 func (statefulSetTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	statefulSet := parametrizeResource(def.StatefulSet, gc,
-	"Spec.Template.Spec.Containers.Env",
-		"Spec.Template.Spec.InitContainers.Env").(*appsbeta1.StatefulSet)
+	statefulSet := parametrizeResource(def.StatefulSet, gc, statefulSetParamFields).(*appsbeta1.StatefulSet)
 	return newStatefulSet(statefulSet, c.StatefulSets(), c, def.Meta)
 }
 

--- a/pkg/scheduler/dependency_graph_test.go
+++ b/pkg/scheduler/dependency_graph_test.go
@@ -28,7 +28,8 @@ func TestAllocateReplicas(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
 	sched := New(c, nil, 0).(*Scheduler)
-	newReplicas1, deleteReplicas, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: 3})
+	newReplicas1, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +42,8 @@ func TestAllocateReplicas(t *testing.T) {
 	}
 	ensureReplicas(c, t, 0, 3)
 
-	newReplicas2, deleteReplicas, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: 1})
+	newReplicas2, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 1}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,10 +56,8 @@ func TestAllocateReplicas(t *testing.T) {
 	}
 	ensureReplicas(c, t, 0, 4)
 
-	allReplicas, deleteReplicas, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{
-		ReplicaCount:          5,
-		FixedNumberOfReplicas: true,
-	})
+	allReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 5, FixedNumberOfReplicas: true}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,8 @@ func TestAllocateReplicas(t *testing.T) {
 		t.Error("replica list is not stable")
 	}
 
-	allReplicas2, deleteReplicas, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: 0})
+	allReplicas2, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 0}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +98,8 @@ func TestDeallocateReplicas(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
 	sched := New(c, nil, 0).(*Scheduler)
-	newReplicas1, deleteReplicas1, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: 5})
+	newReplicas1, deleteReplicas1, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 5}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +112,8 @@ func TestDeallocateReplicas(t *testing.T) {
 	}
 	ensureReplicas(c, t, 0, 5)
 
-	newReplicas2, deleteReplicas2, err := sched.allocateReplicas(flow, interfaces.DependencyGraphOptions{ReplicaCount: -2})
+	newReplicas2, deleteReplicas2, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: -2}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,13 +134,17 @@ func TestDeallocateReplicas(t *testing.T) {
 	ensureReplicas(c, t, 0, 5)
 }
 
+func toContext(options interfaces.DependencyGraphOptions) *GraphContext {
+	return &GraphContext{graph: &DependencyGraph{graphOptions: options}}
+}
+
 // TestAllocateReplicasMinMax tests replica allocation with min/max constraints applied
 func TestAllocateReplicasMinMax(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
 	sched := New(c, nil, 0).(*Scheduler)
 	newReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
-		interfaces.DependencyGraphOptions{ReplicaCount: 3, MinReplicaCount: 5, MaxReplicaCount: 10})
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3, MinReplicaCount: 5, MaxReplicaCount: 10}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +158,7 @@ func TestAllocateReplicasMinMax(t *testing.T) {
 	ensureReplicas(c, t, 0, 5)
 
 	newReplicas, deleteReplicas, _ = sched.allocateReplicas(flow,
-		interfaces.DependencyGraphOptions{ReplicaCount: 9, MinReplicaCount: 5, MaxReplicaCount: 10})
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 9, MinReplicaCount: 5, MaxReplicaCount: 10}))
 
 	if len(newReplicas) != 5 {
 		t.Fatal("unexpected new replica count", len(newReplicas))
@@ -162,7 +169,7 @@ func TestAllocateReplicasMinMax(t *testing.T) {
 	ensureReplicas(c, t, 0, 10)
 
 	newReplicas, deleteReplicas, err = sched.allocateReplicas(flow,
-		interfaces.DependencyGraphOptions{ReplicaCount: -6, MinReplicaCount: 5, MaxReplicaCount: 10})
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: -6, MinReplicaCount: 5, MaxReplicaCount: 10}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -197,7 +197,7 @@ func createResources(toCreate chan *ScheduledResource, finished chan string, ccL
 			onError := resources.GetStringMeta(r.Resource, "on-error", "")
 
 			waitTimeout := WaitTimeout
-			if timeoutInSeconds > 0 {
+			if timeoutInSeconds >= 0 {
 				waitTimeout = time.Second * time.Duration(timeoutInSeconds)
 			}
 


### PR DESCRIPTION
When a service had composite label selector, dependent resource statuses
were checked by selecting resources that match to each of the selector
parts. This is wrong since composite selector should match intersection
of resources with each selector part rather than their union. As a
result service could start depend on resources that have nothing to
do with the service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/249)
<!-- Reviewable:end -->
