### PR TITLE
Flow aware graph cycle detection

### DIFF
--- a/pkg/scheduler/dependency_analyzer.go
+++ b/pkg/scheduler/dependency_analyzer.go
@@ -23,14 +23,17 @@ import (
 	"strings"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 )
 
 // detectCycles implements Kosaraju's algorithm https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
 // for detecting cycles in graph.
 // We are depending on the fact that any strongly connected component of a graph is a cycle
 // if it consists of more than one vertex
-func detectCycles(dependencies []client.Dependency) [][]string {
-	graph := groupDependentResources(dependencies)
+func detectCycles(dependencies []client.Dependency,
+	flows map[string]*client.Flow, flow *client.Flow, useDestructionSelector bool) [][]string {
+
+	graph := groupDependentResources(dependencies, flows, flow, useDestructionSelector)
 
 	// is vertex visited in first phase of the algorithm
 	visited := make(map[string]bool)
@@ -76,9 +79,20 @@ func detectCycles(dependencies []client.Dependency) [][]string {
 	return cycles
 }
 
-func groupDependentResources(dependencies []client.Dependency) (result map[string][]string) {
+func groupDependentResources(dependencies []client.Dependency,
+	flows map[string]*client.Flow, flow *client.Flow, useDestructionSelector bool) (result map[string][]string) {
+
 	result = map[string][]string{}
 	for _, dependency := range dependencies {
+		if !canDependencyBelongToFlow(&dependency, flow, useDestructionSelector) {
+			continue
+		}
+		parentFlow := flows[dependency.Parent]
+		if parentFlow != nil && parentFlow != flow && (canDependencyBelongToFlow(&dependency, parentFlow, true) ||
+			canDependencyBelongToFlow(&dependency, parentFlow, false)) {
+			continue
+		}
+
 		group := result[dependency.Parent]
 		if group == nil {
 			group = []string{dependency.Child}
@@ -133,8 +147,22 @@ func assignVertex(vertex, root string, assigned map[string]bool, components map[
 	}
 }
 
-func EnsureNoCycles(dependencies []client.Dependency) error {
-	cycles := detectCycles(dependencies)
+func EnsureNoCycles(dependencies []client.Dependency, resdefs map[string]client.ResourceDefinition) error {
+	flows := map[string]*client.Flow{}
+	if _, found := resdefs["flow/"+interfaces.DefaultFlowName]; !found {
+		flows["flow/"+interfaces.DefaultFlowName] = newDefaultFlowObject()
+	}
+	for _, v := range resdefs {
+		if v.Flow != nil {
+			flows["flow/"+v.Flow.Name] = v.Flow
+		}
+	}
+
+	var cycles [][]string
+	for _, flow := range flows {
+		cycles = append(cycles, detectCycles(dependencies, flows, flow, false)...)
+		cycles = append(cycles, detectCycles(dependencies, flows, flow, true)...)
+	}
 	if len(cycles) > 0 {
 		message := "Invalid resource graph. The following cycles were detected:\n"
 		for _, cycle := range cycles {

--- a/pkg/scheduler/dependency_graph.go
+++ b/pkg/scheduler/dependency_graph.go
@@ -348,7 +348,7 @@ func (sched *Scheduler) updateContext(context, parentContext *GraphContext, depe
 	context.dependencies = append(context.dependencies, dependency)
 }
 
-func (sched *Scheduler) newDefaultFlowObject() *client.Flow {
+func newDefaultFlowObject() *client.Flow {
 	return &client.Flow{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Flow",
@@ -356,7 +356,6 @@ func (sched *Scheduler) newDefaultFlowObject() *client.Flow {
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      interfaces.DefaultFlowName,
-			Namespace: sched.client.Namespace(),
 		},
 		Exported: true,
 	}
@@ -529,7 +528,7 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 
 	flow := flowResDef.Flow
 	if flow == nil {
-		flow = sched.newDefaultFlowObject()
+		flow = newDefaultFlowObject()
 	}
 
 	if !flow.Exported && options.ExportedOnly {
@@ -552,7 +551,7 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 	if !options.Silent {
 		log.Println("Making sure there is no cycles in the dependency graph")
 	}
-	if err = EnsureNoCycles(depList); err != nil {
+	if err = EnsureNoCycles(depList, resDefs); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Cycle detection algorithm used to detect cycles in the whole
dependency graph ignoring dependency labels and how they correspond
to flow selectors. In some cases this caused false positive result.
For example it could happen if there is a cycle between creation and
destruction flow paths even if they are not related and the deployment
succeeded.

This commit makes cycle detection flow aware. Now the cycles are
searched for each exported flow * 2 paths (construction, destruction).
The validation takes place for all known flows rather than for the one
which is we about to execute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/250)
<!-- Reviewable:end -->
