### PR TITLE
Replicaspace contexts

### DIFF
--- a/e2e/flows_test.go
+++ b/e2e/flows_test.go
@@ -50,8 +50,8 @@ var _ = Describe("Flows Suite", func() {
 			return framework.countPods("test-pod", true)
 		}).Should(Equal(1), "1 test-pod should have been created")
 		Eventually(func() int {
-			return framework.countReplicas("test-flow-", false)
-		}).Should(Equal(2), "2 test-flow* replicas should have been created")
+			return framework.countReplicas("test-flow", true)
+		}).Should(Equal(2), "2 test-flow replicas should have been created")
 		Eventually(func() int {
 			return framework.countReplicas("DEFAULT", true)
 		}).Should(Equal(1), "1 DEFAULT flow replica should have been created")
@@ -78,8 +78,8 @@ var _ = Describe("Flows Suite", func() {
 			return framework.countPods("test-pod", true)
 		}).Should(Equal(1), "1 test-pod should have been created")
 		Eventually(func() int {
-			return framework.countReplicas("test-flow-", false)
-		}).Should(Equal(4), "2 test-flow* replicas should have been created")
+			return framework.countReplicas("test-flow", true)
+		}).Should(Equal(4), "2 test-flow replicas should have been created")
 		Eventually(func() int {
 			return framework.countReplicas("DEFAULT", true)
 		}).Should(Equal(2), "1 DEFAULT flow replica should have been created")
@@ -140,10 +140,10 @@ func (ff FlowFramework) countJobs(prefix string, equal bool) int {
 }
 
 func (ff FlowFramework) countReplicas(prefix string, equal bool) int {
-	jobs, err := ff.Client.Replicas().List(api.ListOptions{})
+	replicas, err := ff.Client.Replicas().List(api.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	count := 0
-	for _, item := range jobs.Items {
+	for _, item := range replicas.Items {
 		if equal && item.ReplicaSpace == prefix ||
 			!equal && strings.HasPrefix(item.ReplicaSpace, prefix) && len(item.ReplicaSpace) > len(prefix) {
 			count++

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -68,6 +68,7 @@ type DeploymentReport interface {
 type DependencyGraph interface {
 	GetStatus() (DeploymentStatus, DeploymentReport)
 	Deploy(<-chan struct{})
+	Options() DependencyGraphOptions
 }
 
 type GraphContext interface {

--- a/pkg/scheduler/dependency_analyzer.go
+++ b/pkg/scheduler/dependency_analyzer.go
@@ -23,14 +23,17 @@ import (
 	"strings"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 )
 
 // detectCycles implements Kosaraju's algorithm https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
 // for detecting cycles in graph.
 // We are depending on the fact that any strongly connected component of a graph is a cycle
 // if it consists of more than one vertex
-func detectCycles(dependencies []client.Dependency) [][]string {
-	graph := groupDependentResources(dependencies)
+func detectCycles(dependencies []client.Dependency,
+	flows map[string]*client.Flow, flow *client.Flow, useDestructionSelector bool) [][]string {
+
+	graph := groupDependentResources(dependencies, flows, flow, useDestructionSelector)
 
 	// is vertex visited in first phase of the algorithm
 	visited := make(map[string]bool)
@@ -76,9 +79,20 @@ func detectCycles(dependencies []client.Dependency) [][]string {
 	return cycles
 }
 
-func groupDependentResources(dependencies []client.Dependency) (result map[string][]string) {
+func groupDependentResources(dependencies []client.Dependency,
+	flows map[string]*client.Flow, flow *client.Flow, useDestructionSelector bool) (result map[string][]string) {
+
 	result = map[string][]string{}
 	for _, dependency := range dependencies {
+		if !canDependencyBelongToFlow(&dependency, flow, useDestructionSelector) {
+			continue
+		}
+		parentFlow := flows[dependency.Parent]
+		if parentFlow != nil && parentFlow != flow && (canDependencyBelongToFlow(&dependency, parentFlow, true) ||
+			canDependencyBelongToFlow(&dependency, parentFlow, false)) {
+			continue
+		}
+
 		group := result[dependency.Parent]
 		if group == nil {
 			group = []string{dependency.Child}
@@ -133,8 +147,22 @@ func assignVertex(vertex, root string, assigned map[string]bool, components map[
 	}
 }
 
-func EnsureNoCycles(dependencies []client.Dependency) error {
-	cycles := detectCycles(dependencies)
+func EnsureNoCycles(dependencies []client.Dependency, resdefs map[string]client.ResourceDefinition) error {
+	flows := map[string]*client.Flow{}
+	if _, found := resdefs["flow/"+interfaces.DefaultFlowName]; !found {
+		flows["flow/"+interfaces.DefaultFlowName] = newDefaultFlowObject()
+	}
+	for _, v := range resdefs {
+		if v.Flow != nil {
+			flows["flow/"+v.Flow.Name] = v.Flow
+		}
+	}
+
+	var cycles [][]string
+	for _, flow := range flows {
+		cycles = append(cycles, detectCycles(dependencies, flows, flow, false)...)
+		cycles = append(cycles, detectCycles(dependencies, flows, flow, true)...)
+	}
 	if len(cycles) > 0 {
 		message := "Invalid resource graph. The following cycles were detected:\n"
 		for _, cycle := range cycles {

--- a/pkg/scheduler/dependency_graph.go
+++ b/pkg/scheduler/dependency_graph.go
@@ -348,7 +348,7 @@ func (sched *Scheduler) updateContext(context, parentContext *GraphContext, depe
 	context.dependencies = append(context.dependencies, dependency)
 }
 
-func (sched *Scheduler) newDefaultFlowObject() *client.Flow {
+func newDefaultFlowObject() *client.Flow {
 	return &client.Flow{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Flow",
@@ -356,7 +356,6 @@ func (sched *Scheduler) newDefaultFlowObject() *client.Flow {
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:      interfaces.DefaultFlowName,
-			Namespace: sched.client.Namespace(),
 		},
 		Exported: true,
 	}
@@ -529,7 +528,7 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 
 	flow := flowResDef.Flow
 	if flow == nil {
-		flow = sched.newDefaultFlowObject()
+		flow = newDefaultFlowObject()
 	}
 
 	if !flow.Exported && options.ExportedOnly {
@@ -552,7 +551,7 @@ func (sched *Scheduler) BuildDependencyGraph(options interfaces.DependencyGraphO
 	if !options.Silent {
 		log.Println("Making sure there is no cycles in the dependency graph")
 	}
-	if err = EnsureNoCycles(depList); err != nil {
+	if err = EnsureNoCycles(depList, resDefs); err != nil {
 		return nil, err
 	}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -300,6 +300,11 @@ func ignoreAll(top *ScheduledResource) {
 	}
 }
 
+// Options method returns options that were used to build the dependency graph
+func (depGraph DependencyGraph) Options() interfaces.DependencyGraphOptions {
+	return depGraph.graphOptions
+}
+
 // Deploy starts the deployment of a DependencyGraph
 func (depGraph DependencyGraph) Deploy(stopChan <-chan struct{}) {
 


### PR DESCRIPTION
In order to be idempotent, Create() method of the flow resource used
MinReplicaCount set to 1 and ReplicaCount set to 0. This ensured that
at least one flow replica was created and no new replicas created on
subsequent calls. If we use ReplicaCount=1 it would cause all other
replicas of the flow to be deleted. 
But this workaround is also not always correct. The problem is when
the flow has fixed replica-space. If such flow is triggered from another
flow, and say, we want to have additional N replicas of that outer flow,
all replicas of the outer flow will trigger deployment of our (inner)
flow N times, but still only 1 replica will be created.

The solution is to divide replicaspace. With this change, for each
use of the inner flow the replica object will get a composite label
replicaspace=xxx, context=yyy where context is different for each usage
of the inner flow. Thus it becomes safe to use ReplicaCount=1 since
now the inner flow sees only its own replica. But when the flow is not
run in context of another flow, it will use only the replicaspace part
of the selector and thus will see of the replicas in all contexts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/251)
<!-- Reviewable:end -->
