### PR TITLE
HA for relative replica count deployments

### DIFF
--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -70,16 +70,21 @@ type FlowParameter struct {
 
 // Replica resource represents one instance of the replicated flow. Since the only difference between replicas is their
 // $AC_NAME value which is replica name this resource is only needed to generate unique name for each replica and make
-// those name persistent so that we could do CRD (CRUD without "U") on the list of replica names
+// those name persistent so that we could do CRUD on the list of replica names
 type Replica struct {
 	unversioned.TypeMeta `json:",inline"`
 
 	// Standard object metadata
 	api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
+	// flow name
 	FlowName string `json:"flowName,omitempty"`
 
+	// replica-space name
 	ReplicaSpace string `json:"replicaSpace,omitempty"`
+
+	// AC sets this field to true after deployment of the dependency graph for this replica
+	Deployed bool `json:"deployed,omitempty"`
 }
 
 // ReplicaList is a list of replicas
@@ -97,6 +102,7 @@ type ReplicasInterface interface {
 	List(opts api.ListOptions) (*ReplicaList, error)
 	Create(replica *Replica) (*Replica, error)
 	Delete(name string) error
+	Update(replica *Replica) error
 }
 
 type replicas struct {
@@ -156,6 +162,17 @@ func (r *replicas) Delete(name string) error {
 		Name(name).
 		Do().
 		Error()
+}
+
+// Update persists object changes back to k8s
+func (r *replicas) Update(replica *Replica) error {
+	_, err := r.rc.Put().
+		Namespace(r.namespace).
+		Resource("replicas").
+		Name(replica.Name).
+		Body(replica).
+		DoRaw()
+	return err
 }
 
 // ReplicaName returns replica name (which then goes into $AC_NAME var) encoded in Replica k8s object name

--- a/pkg/mocks/fake_replicas.go
+++ b/pkg/mocks/fake_replicas.go
@@ -61,14 +61,11 @@ func (fr *fakeReplicas) Create(replica *client.Replica) (result *client.Replica,
 }
 
 // Update updates Replica object stored in the fake k8s
-func (fr *fakeReplicas) Update(replica *client.Replica) (result *client.Replica, err error) {
-	obj, err := fr.fake.
+func (fr *fakeReplicas) Update(replica *client.Replica) error {
+	_, err := fr.fake.
 		Invokes(testing.NewUpdateAction(replicaResource, fr.ns, replica), &client.Replica{})
 
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*client.Replica), err
+	return err
 }
 
 // Delete deletes a replica object by its name

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -91,6 +91,9 @@ func (f *flow) buildDependencyGraph(replicaCount int, silent bool) (interfaces.D
 	fixedNumberOfReplicas := false
 	if replicaCount > 0 {
 		fixedNumberOfReplicas = f.context.Graph().Options().FixedNumberOfReplicas
+	} else if replicaCount == 0 {
+		fixedNumberOfReplicas = true
+		replicaCount = -1
 	}
 	options := interfaces.DependencyGraphOptions{
 		FlowName:              f.originalName,

--- a/pkg/scheduler/dependency_graph_test.go
+++ b/pkg/scheduler/dependency_graph_test.go
@@ -15,12 +15,12 @@
 package scheduler
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
 	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 	"github.com/Mirantis/k8s-AppController/pkg/mocks"
+	"k8s.io/client-go/pkg/api"
 )
 
 // TestAllocateReplicas tests replica allocation in different configurations
@@ -41,6 +41,7 @@ func TestAllocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
 	ensureReplicas(c, t, 0, 3)
+	acknowledgeReplicas(c, t)
 
 	newReplicas2, deleteReplicas, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 1}))
@@ -55,6 +56,7 @@ func TestAllocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
 	ensureReplicas(c, t, 0, 4)
+	acknowledgeReplicas(c, t)
 
 	allReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 5, FixedNumberOfReplicas: true}))
@@ -69,9 +71,15 @@ func TestAllocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
 	ensureReplicas(c, t, 0, 5)
+	acknowledgeReplicas(c, t)
 
-	if !reflect.DeepEqual(newReplicas2[0], allReplicas[3]) || !reflect.DeepEqual(newReplicas1, allReplicas[:3]) {
+	if newReplicas2[0].Name != allReplicas[3].Name {
 		t.Error("replica list is not stable")
+	}
+	for i, r := range newReplicas1 {
+		if r.Name != allReplicas[i].Name {
+			t.Error("replica list is not stable")
+		}
 	}
 
 	allReplicas2, deleteReplicas, err := sched.allocateReplicas(flow,
@@ -88,8 +96,10 @@ func TestAllocateReplicas(t *testing.T) {
 	}
 	ensureReplicas(c, t, 0, 5)
 
-	if !reflect.DeepEqual(allReplicas, allReplicas2) {
-		t.Error("replica list is not stable")
+	for i, r := range allReplicas {
+		if r.Name != allReplicas2[i].Name {
+			t.Error("replica list is not stable")
+		}
 	}
 }
 
@@ -111,6 +121,7 @@ func TestDeallocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas1))
 	}
 	ensureReplicas(c, t, 0, 5)
+	acknowledgeReplicas(c, t)
 
 	newReplicas2, deleteReplicas2, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: -2}))
@@ -125,10 +136,11 @@ func TestDeallocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas2))
 	}
 
-	if !reflect.DeepEqual(deleteReplicas2, newReplicas1[3:]) {
-		t.Error("last created replicas should have been scheduled for deletion")
+	for i, replica := range deleteReplicas2 {
+		if replica.Name != newReplicas1[3+i].Name {
+			t.Error("last created replicas should have been scheduled for deletion")
+		}
 	}
-
 	// allocateReplicas can only create new Replica objects in k8s, but not delete existing
 	// replicas can only be deleted when all the resources belonging to it are deleted which happens after deployment
 	ensureReplicas(c, t, 0, 5)
@@ -156,17 +168,19 @@ func TestAllocateReplicasMinMax(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
 	ensureReplicas(c, t, 0, 5)
+	acknowledgeReplicas(c, t)
 
 	newReplicas, deleteReplicas, _ = sched.allocateReplicas(flow,
-		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 9, MinReplicaCount: 5, MaxReplicaCount: 10}))
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 9, MinReplicaCount: 5, MaxReplicaCount: 11}))
 
-	if len(newReplicas) != 5 {
+	if len(newReplicas) != 6 {
 		t.Fatal("unexpected new replica count", len(newReplicas))
 	}
 	if len(deleteReplicas) != 0 {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
-	ensureReplicas(c, t, 0, 10)
+	ensureReplicas(c, t, 0, 11)
+	acknowledgeReplicas(c, t)
 
 	newReplicas, deleteReplicas, err = sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: -6, MinReplicaCount: 5, MaxReplicaCount: 10}))
@@ -177,10 +191,60 @@ func TestAllocateReplicasMinMax(t *testing.T) {
 	if len(newReplicas) != 0 {
 		t.Fatal("unexpected new replica count", len(newReplicas))
 	}
-	if len(deleteReplicas) != 5 {
+	if len(deleteReplicas) != 6 {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
-	ensureReplicas(c, t, 0, 10)
+	ensureReplicas(c, t, 0, 11)
+}
+
+// TestRepeatRelativeReplicaAllocation tests that repeated allocation of the same relative amount of replica
+// creates replicas on the first call only
+func TestRepeatRelativeReplicaAllocation(t *testing.T) {
+	flow := mocks.MakeFlow("flow").Flow
+	c := mocks.NewClient()
+	sched := New(c, nil, 0).(*scheduler)
+	newReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(newReplicas) != 3 {
+		t.Fatal("unexpected new replica count", len(newReplicas))
+	}
+	if len(deleteReplicas) != 0 {
+		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
+	}
+
+	newReplicas2, deleteReplicas2, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(deleteReplicas2) != 0 {
+		t.Fatal("unexpected doomed replica count", len(deleteReplicas2))
+	}
+	if len(newReplicas2) != 3 {
+		t.Fatal("unexpected new replica count", len(newReplicas2))
+	}
+	for i := range newReplicas {
+		if newReplicas[i].Name != newReplicas2[i].Name {
+			t.Errorf("replica list differs: %s != %s", newReplicas[i].Name, newReplicas2[i].Name)
+		}
+	}
+}
+
+func acknowledgeReplicas(c client.Interface, t *testing.T) {
+	iface := c.Replicas()
+	list, err := iface.List(api.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range list.Items {
+		r.Deployed = true
+		iface.Update(&r)
+	}
 }
 
 // TestDependencyToFlowMatching tests how AC identifies if dependency belongs to a given flow path or not

--- a/pkg/scheduler/frontend.go
+++ b/pkg/scheduler/frontend.go
@@ -190,11 +190,9 @@ func GetStatus(client client.Interface, selector labels.Selector,
 	if options.FlowName == "" {
 		options.FlowName = interfaces.DefaultFlowName
 	}
-	options.ReplicaCount = 0
+	options.ReplicaCount = -1
+	options.FixedNumberOfReplicas = true
 	options.Silent = true
-	options.FixedNumberOfReplicas = false
-	options.MinReplicaCount = 0
-	options.MaxReplicaCount = 0
 
 	if !silent {
 		log.Println("Getting status of flow", options.FlowName)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -344,7 +344,6 @@ func (depGraph dependencyGraph) Deploy(stopChan <-chan struct{}) {
 		}
 	}
 	if depGraph.finalizer != nil {
-		log.Print("Performing resource cleanup")
 		depGraph.finalizer()
 	}
 	// TODO Make sure every KO gets created eventually


### PR DESCRIPTION
Currently, flow deployments are HA only when fixed replica count is
specified. If we run `kubeac run flow -n+2` and then the deployment
fail in the middle, after recovery it will create another 2 replicas
so we are going to get 4 new replicas instead of 2

With this change, Replica objects get additional boolean field
`Deployed` which is set to true upon replica deployment. Until then,
replica allocation algorithm will allocate replicas from previous
failed deployment (i.e. where Deployed = false) first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/257)
<!-- Reviewable:end -->
