### PR TITLE
Fixes gofmt and golint warnings

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -24,7 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Deploy *cobra.Command = initDeployCommand()
+// Deploy is the deploy CLI command object
+var Deploy = initDeployCommand()
 
 func deploy(cmd *cobra.Command, args []string) {
 	url, err := cmd.Flags().GetString("url")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -59,12 +59,12 @@ func TestLabelFlag(t *testing.T) {
 
 // TestParseArg tests how key-value arguments are parsed in command line interface
 func TestParseArg(t *testing.T) {
-	table := []struct{
-		arg string
-		key string
+	table := []struct {
+		arg   string
+		key   string
 		value string
 		error bool
-	} {
+	}{
 		{"x=y", "x", "y", false},
 		{"x:y", "x", "y", false},
 		{"x = y", "x", "y", false},

--- a/e2e/example_runner.go
+++ b/e2e/example_runner.go
@@ -35,11 +35,11 @@ import (
 	"k8s.io/client-go/pkg/runtime"
 )
 
-type ExamplesFramework struct {
+type examplesFramework struct {
 	*utils.AppControllerManager
 }
 
-func (f *ExamplesFramework) CreateExample(exampleName string) {
+func (f *examplesFramework) CreateExample(exampleName string) {
 	// list all files in directory, for each file run Create
 	fqDir := filepath.Join(utils.TestContext.Examples, exampleName)
 	By("Creating example from directory " + fqDir)
@@ -52,7 +52,7 @@ func (f *ExamplesFramework) CreateExample(exampleName string) {
 	}
 }
 
-func (f *ExamplesFramework) Create(fileName string) {
+func (f *examplesFramework) Create(fileName string) {
 	// Load data from filepath
 	// try to serialize it into Unstructured or UnstructuredList
 	data, err := ioutil.ReadFile(fileName)
@@ -74,7 +74,7 @@ func (f *ExamplesFramework) Create(fileName string) {
 	})
 }
 
-func (f *ExamplesFramework) handleItemCreation(ust *runtime.Unstructured) {
+func (f *examplesFramework) handleItemCreation(ust *runtime.Unstructured) {
 	// based on kind of item - instantiate correct object and wrap it with resource definition
 	// if unstructured is of kind Dependency - just create it as is
 	encodedData, err := json.Marshal(ust)
@@ -98,13 +98,13 @@ func (f *ExamplesFramework) handleItemCreation(ust *runtime.Unstructured) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func (f *ExamplesFramework) handleListCreation(ustList *runtime.UnstructuredList) {
+func (f *examplesFramework) handleListCreation(ustList *runtime.UnstructuredList) {
 	for _, ust := range ustList.Items {
 		f.handleItemCreation(ust)
 	}
 }
 
-func (f *ExamplesFramework) VerifyStatus(task string, options interfaces.DependencyGraphOptions) {
+func (f *examplesFramework) VerifyStatus(task string, options interfaces.DependencyGraphOptions) {
 	var depReport report.DeploymentReport
 	Eventually(
 		func() bool {
@@ -123,7 +123,7 @@ func (f *ExamplesFramework) VerifyStatus(task string, options interfaces.Depende
 		300*time.Second, 5*time.Second).Should(BeTrue(), strings.Join(depReport.AsText(0), "\n"))
 }
 
-func (f *ExamplesFramework) CreateRunAndVerify(exampleName string, options interfaces.DependencyGraphOptions) {
+func (f *examplesFramework) CreateRunAndVerify(exampleName string, options interfaces.DependencyGraphOptions) {
 	By("Creating example " + exampleName)
 	f.CreateExample(exampleName)
 	By("Running appcontroller scheduler")

--- a/e2e/examples_test.go
+++ b/e2e/examples_test.go
@@ -23,7 +23,7 @@ import (
 
 var _ = Describe("Examples Suite", func() {
 	options := interfaces.DependencyGraphOptions{ReplicaCount: 1}
-	framework := ExamplesFramework{testutils.NewAppControllerManager()}
+	framework := examplesFramework{testutils.NewAppControllerManager()}
 
 	It("Example 'simple' should finish", func() {
 		framework.CreateRunAndVerify("simple", options)

--- a/e2e/flows_test.go
+++ b/e2e/flows_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var _ = Describe("Flows Suite", func() {
-	framework := FlowFramework{ExamplesFramework{testutils.NewAppControllerManager()}}
+	framework := FlowFramework{examplesFramework{testutils.NewAppControllerManager()}}
 
 	It("Example 'flows' should finish and create one graph replica", func() {
 		framework.CreateRunAndVerify("flows", interfaces.DependencyGraphOptions{MinReplicaCount: 1})
@@ -107,7 +107,7 @@ var _ = Describe("Flows Suite", func() {
 })
 
 type FlowFramework struct {
-	ExamplesFramework
+	examplesFramework
 }
 
 func (ff FlowFramework) countPods(prefix string, equal bool) int {

--- a/e2e/utils/appcmanager.go
+++ b/e2e/utils/appcmanager.go
@@ -33,6 +33,7 @@ const (
 	appcontrollerPod = "k8s-appcontroller"
 )
 
+// AppControllerManager is the test controller exposes remote AC operations and test primitives for dependency graphs
 type AppControllerManager struct {
 	Client    client.Interface
 	Clientset *kubernetes.Clientset
@@ -42,10 +43,12 @@ type AppControllerManager struct {
 	acPod *v1.Pod
 }
 
+// Run runs dependency graph deployment with default settings
 func (a *AppControllerManager) Run() string {
 	return a.RunWithOptions(interfaces.DependencyGraphOptions{MinReplicaCount: 1})
 }
 
+// RunWithOptions runs dependency graph deployment with given settings
 func (a *AppControllerManager) RunWithOptions(options interfaces.DependencyGraphOptions) string {
 	sched := scheduler.New(a.Client, nil, 0)
 
@@ -54,6 +57,7 @@ func (a *AppControllerManager) RunWithOptions(options interfaces.DependencyGraph
 	return task
 }
 
+// DeleteAppControllerPod deletes pod, where AppController is running
 func (a *AppControllerManager) DeleteAppControllerPod() {
 	By("Removing pod  " + appcontrollerPod)
 	err := a.Client.Pods().Delete(appcontrollerPod, nil)
@@ -64,6 +68,7 @@ func (a *AppControllerManager) DeleteAppControllerPod() {
 	}, 20*time.Second, 1*time.Second).Should(BeTrue(), "Appcontroller pod wasn't removed in time")
 }
 
+// Prepare starts AppController pod
 func (a *AppControllerManager) Prepare() {
 	appControllerObj := &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
@@ -105,6 +110,7 @@ func (a *AppControllerManager) Prepare() {
 	}, 120*time.Second, 5*time.Second).Should(BeTrue())
 }
 
+// BeforeEach is an action executed before each test
 func (a *AppControllerManager) BeforeEach() {
 	var err error
 	a.Clientset, err = KubeClient()
@@ -127,6 +133,7 @@ func (a *AppControllerManager) BeforeEach() {
 	a.Prepare()
 }
 
+// AfterEach is an action executed after each test
 func (a *AppControllerManager) AfterEach() {
 	By("Dumping appcontroller logs")
 	if CurrentGinkgoTestDescription().Failed && a.acPod != nil {
@@ -137,6 +144,7 @@ func (a *AppControllerManager) AfterEach() {
 	RemoveServiceAccountFromAdmins(a.Clientset)
 }
 
+// NewAppControllerManager creates new instance of AppControllerManager
 func NewAppControllerManager() *AppControllerManager {
 	appc := &AppControllerManager{}
 	BeforeEach(appc.BeforeEach)

--- a/pkg/client/dependencies.go
+++ b/pkg/client/dependencies.go
@@ -23,27 +23,38 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// Dependency represents dependency between two resources / resource definitions
 type Dependency struct {
 	unversioned.TypeMeta `json:",inline"`
 
 	// Standard object metadata
 	api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	Parent string            `json:"parent"`
-	Child  string            `json:"child"`
-	Meta   map[string]string `json:"meta,omitempty"`
-	Args   map[string]string `json:"args,omitempty"`
+	// Depending resource name
+	Parent string `json:"parent"`
+
+	// Dependent resource name
+	Child string `json:"child"`
+
+	// Dependency metadata
+	Meta map[string]string `json:"meta,omitempty"`
+
+	// Arguments passed to dependent resource
+	Args map[string]string `json:"args,omitempty"`
 }
 
+// DependencyList is a k8s object representing list of dependencies
 type DependencyList struct {
 	unversioned.TypeMeta `json:",inline"`
 
 	// Standard list metadata.
 	unversioned.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
+	// List of dependencies
 	Items []Dependency `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
+// DependenciesInterface is an interface to access Dependency objects in k8s
 type DependenciesInterface interface {
 	List(opts api.ListOptions) (*DependencyList, error)
 	Create(*Dependency) (*Dependency, error)
@@ -64,6 +75,7 @@ func newDependencies(c rest.Config, ns string) (*dependencies, error) {
 	return &dependencies{rc, ns}, nil
 }
 
+// List returns Dependency objects stored in K8s
 func (c dependencies) List(opts api.ListOptions) (*DependencyList, error) {
 	resp, err := c.rc.Get().
 		Namespace(c.namespace).
@@ -84,6 +96,7 @@ func (c dependencies) List(opts api.ListOptions) (*DependencyList, error) {
 	return result, nil
 }
 
+// Create creates new Dependency object in K8s
 func (c dependencies) Create(d *Dependency) (result *Dependency, err error) {
 	result = &Dependency{}
 	err = c.rc.Post().
@@ -95,6 +108,7 @@ func (c dependencies) Create(d *Dependency) (result *Dependency, err error) {
 	return
 }
 
+// Delete deletes Dependency object from K8s
 func (c *dependencies) Delete(name string, opts *api.DeleteOptions) error {
 	return c.rc.Delete().
 		Namespace(c.namespace).

--- a/pkg/client/resdef.go
+++ b/pkg/client/resdef.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// ResourceDefinition represents template for one of supported k8s resource types
 type ResourceDefinition struct {
 	unversioned.TypeMeta `json:",inline"`
 
@@ -54,6 +55,7 @@ type ResourceDefinition struct {
 	Flow                  *Flow                     `json:"flow, omitempty"`
 }
 
+// ResourceDefinitionList is a k8s object representing list of resource definitions
 type ResourceDefinitionList struct {
 	unversioned.TypeMeta `json:",inline"`
 
@@ -63,6 +65,7 @@ type ResourceDefinitionList struct {
 	Items []ResourceDefinition `json:"items"`
 }
 
+// ResourceDefinitionsInterface is an interface to access Definition objects in k8s
 type ResourceDefinitionsInterface interface {
 	Create(*ResourceDefinition) (*ResourceDefinition, error)
 	List(opts api.ListOptions) (*ResourceDefinitionList, error)
@@ -74,10 +77,12 @@ type resourceDefinitions struct {
 	namespace string
 }
 
+// GetObjectKind returns type header of ResourceDefinition object
 func (r *ResourceDefinition) GetObjectKind() unversioned.ObjectKind {
 	return &r.TypeMeta
 }
 
+// GetObjectMeta returns metadata of ResourceDefinition object
 func (r *ResourceDefinition) GetObjectMeta() meta.Object {
 	return &r.ObjectMeta
 }
@@ -91,6 +96,7 @@ func newResourceDefinitions(c rest.Config, ns string) (*resourceDefinitions, err
 	return &resourceDefinitions{rc, ns}, nil
 }
 
+// List returns Definition objects stored in K8s
 func (c *resourceDefinitions) List(opts api.ListOptions) (*ResourceDefinitionList, error) {
 	resp, err := c.rc.Get().
 		Namespace(c.namespace).
@@ -111,6 +117,7 @@ func (c *resourceDefinitions) List(opts api.ListOptions) (*ResourceDefinitionLis
 	return result, nil
 }
 
+// Create creates new Definition object in K8s
 func (c *resourceDefinitions) Create(rd *ResourceDefinition) (result *ResourceDefinition, err error) {
 	result = &ResourceDefinition{}
 	err = c.rc.Post().
@@ -122,6 +129,7 @@ func (c *resourceDefinitions) Create(rd *ResourceDefinition) (result *ResourceDe
 	return
 }
 
+// Delete deletes Definition object from K8s
 func (c *resourceDefinitions) Delete(name string, opts *api.DeleteOptions) error {
 	return c.rc.Delete().
 		Namespace(c.namespace).

--- a/pkg/copier/copier.go
+++ b/pkg/copier/copier.go
@@ -173,6 +173,7 @@ func addToPath(path, name string, replaceIn ...string) (string, bool) {
 	return newPath, false
 }
 
+// EvaluateString expands all variables in the string and returns evaluated result
 func EvaluateString(template string, replacementsFunc func(string) string) string {
 	return varsRe.ReplaceAllStringFunc(template, func(p string) string {
 		return replacementsFunc(p[1:])

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -18,14 +18,17 @@ import (
 	"github.com/Mirantis/k8s-AppController/pkg/client"
 )
 
+// ResourceStatus is an enum of k8s resource statuses
 type ResourceStatus string
 
+// Possible ResourceStatus values
 const (
 	ResourceReady    ResourceStatus = "ready"
 	ResourceNotReady ResourceStatus = "not ready"
 	ResourceError    ResourceStatus = "error"
 )
 
+// DefaultFlowName is the name of default flow (main dependency graph)
 const DefaultFlowName = "DEFAULT"
 
 // BaseResource is an interface for AppController supported resources
@@ -61,16 +64,20 @@ type ResourceTemplate interface {
 	NewExisting(string, client.Interface, GraphContext) Resource
 }
 
+// DeploymentReport is an interface to get string representation of current deployment progress
 type DeploymentReport interface {
 	AsText(int) []string
 }
 
+// DependencyGraph represents operations on dependency graph
 type DependencyGraph interface {
 	GetStatus() (DeploymentStatus, DeploymentReport)
 	Deploy(<-chan struct{})
 	Options() DependencyGraphOptions
 }
 
+// GraphContext represents context of dependency graph. Resource factories get implementation of this interface
+// so that they can get graph, they created in, its options, arguments and call Scheduler API
 type GraphContext interface {
 	Scheduler() Scheduler
 	GetArg(string) string
@@ -78,6 +85,7 @@ type GraphContext interface {
 	Dependencies() []client.Dependency
 }
 
+// DependencyGraphOptions contains all the input required to build a dependency graph
 type DependencyGraphOptions struct {
 	FlowName                     string
 	Args                         map[string]string
@@ -92,6 +100,7 @@ type DependencyGraphOptions struct {
 	Silent                       bool
 }
 
+// Scheduler interface is an API to build dependency graphs and manage their settings
 type Scheduler interface {
 	BuildDependencyGraph(options DependencyGraphOptions) (DependencyGraph, error)
 	Serialize(options DependencyGraphOptions) map[string]string

--- a/pkg/mocks/client.go
+++ b/pkg/mocks/client.go
@@ -26,16 +26,15 @@ import (
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 	"k8s.io/client-go/pkg/runtime"
 	"k8s.io/client-go/testing"
-
 )
 
 func newClientWithFake(apiVersions *unversioned.APIGroupList, objects ...runtime.Object) (client.Interface, *testing.Fake) {
 	ns := "testing"
 	fakeClientset := fake.NewSimpleClientset(objects...)
 	apps := &alphafake.FakeApps{&fakeClientset.Fake}
-	deps := &FakeDeps{fake: &fakeClientset.Fake, ns: ns}
-	replicas := &FakeReplicas{fake: &fakeClientset.Fake, ns: ns}
-	resDefs := &FakeResDef{fake: &fakeClientset.Fake, ns: ns}
+	deps := &fakeDeps{fake: &fakeClientset.Fake, ns: ns}
+	replicas := &fakeReplicas{fake: &fakeClientset.Fake, ns: ns}
+	resDefs := &fakeResDef{fake: &fakeClientset.Fake, ns: ns}
 	return client.NewClient(
 		fakeClientset,
 		apps,
@@ -60,14 +59,17 @@ func makeVersionsList(version unversioned.GroupVersion) *unversioned.APIGroupLis
 	}}
 }
 
+// NewClient returns new fake client
 func NewClient(objects ...runtime.Object) client.Interface {
 	return newClient(makeVersionsList(v1beta1.SchemeGroupVersion), objects...)
 }
 
+// NewClientWithFake returns new fake client and *testing.Fake object that can be used to catch client events
 func NewClientWithFake(objects ...runtime.Object) (client.Interface, *testing.Fake) {
 	return newClientWithFake(makeVersionsList(v1beta1.SchemeGroupVersion), objects...)
 }
 
+// NewClient1_4 returns fake client for K8s 1.4.x
 func NewClient1_4(objects ...runtime.Object) client.Interface {
 	return newClient(makeVersionsList(v1alpha1.SchemeGroupVersion), objects...)
 }

--- a/pkg/mocks/configmaps.go
+++ b/pkg/mocks/configmaps.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/pkg/runtime"
 )
 
+// MakeConfigMap generates sample ConfigMap object
 func MakeConfigMap(name string) *v1.ConfigMap {
 	configMap := &v1.ConfigMap{}
 	configMap.Name = name
@@ -28,6 +29,7 @@ func MakeConfigMap(name string) *v1.ConfigMap {
 	return configMap
 }
 
+// ConfigMaps generates sample ConfigMapList collection object
 func ConfigMaps(names ...string) runtime.Object {
 	var configMaps []v1.ConfigMap
 	for i := 0; i < 3; i++ {

--- a/pkg/mocks/dependencies.go
+++ b/pkg/mocks/dependencies.go
@@ -24,8 +24,9 @@ import (
 	"k8s.io/client-go/pkg/api"
 )
 
-var counter int32 = 0
+var counter int32
 
+// MakeDependency generates Dependency object
 func MakeDependency(parent, child string, label ...string) *client.Dependency {
 	labelMap := map[string]string{}
 	for _, l := range label {

--- a/pkg/mocks/fake_dependencies.go
+++ b/pkg/mocks/fake_dependencies.go
@@ -23,8 +23,7 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// FakeDeps implements DependenciesInterface
-type FakeDeps struct {
+type fakeDeps struct {
 	fake *testing.Fake
 	ns   string
 }
@@ -35,7 +34,8 @@ var dependencyResource = unversioned.GroupVersionResource{
 	Resource: "dependencies",
 }
 
-func (c *FakeDeps) Create(dependency *client.Dependency) (result *client.Dependency, err error) {
+// Create creates new Dependency object in fake K8s
+func (c *fakeDeps) Create(dependency *client.Dependency) (result *client.Dependency, err error) {
 	obj, err := c.fake.
 		Invokes(testing.NewCreateAction(dependencyResource, c.ns, dependency), &client.Dependency{})
 
@@ -45,41 +45,16 @@ func (c *FakeDeps) Create(dependency *client.Dependency) (result *client.Depende
 	return obj.(*client.Dependency), err
 }
 
-func (c *FakeDeps) Update(dependency *client.Dependency) (result *client.Dependency, err error) {
-	obj, err := c.fake.
-		Invokes(testing.NewUpdateAction(dependencyResource, c.ns, dependency), &client.Dependency{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*client.Dependency), err
-}
-
-func (c *FakeDeps) Delete(name string, options *api.DeleteOptions) error {
+// Delete deletes Dependency from fake K8s
+func (c *fakeDeps) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.fake.
 		Invokes(testing.NewDeleteAction(dependencyResource, c.ns, name), &client.Dependency{})
 
 	return err
 }
 
-func (c *FakeDeps) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(dependencyResource, c.ns, listOptions)
-
-	_, err := c.fake.Invokes(action, &client.DependencyList{})
-	return err
-}
-
-func (c *FakeDeps) Get(name string) (result *client.Dependency, err error) {
-	obj, err := c.fake.
-		Invokes(testing.NewGetAction(dependencyResource, c.ns, name), &client.Dependency{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*client.Dependency), err
-}
-
-func (c *FakeDeps) List(opts api.ListOptions) (result *client.DependencyList, err error) {
+// List returns Dependency objects stored in fake K8s
+func (c *fakeDeps) List(opts api.ListOptions) (result *client.DependencyList, err error) {
 	obj, err := c.fake.
 		Invokes(testing.NewListAction(dependencyResource, c.ns, opts), &client.DependencyList{})
 

--- a/pkg/mocks/fake_replicas.go
+++ b/pkg/mocks/fake_replicas.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// FakeReplicas implements ReplicaInterface
-type FakeReplicas struct {
+// fakeReplicas implements ReplicaInterface
+type fakeReplicas struct {
 	fake *testing.Fake
 	ns   string
 }
@@ -40,7 +40,8 @@ var replicaResource = unversioned.GroupVersionResource{
 	Resource: "replica",
 }
 
-func (fr *FakeReplicas) Create(replica *client.Replica) (result *client.Replica, err error) {
+// Create stores new replica object in the fake k8s
+func (fr *fakeReplicas) Create(replica *client.Replica) (result *client.Replica, err error) {
 	if replica.GenerateName != "" {
 		uuid, _ := newUUID()
 		replica.Name = replica.GenerateName + uuid
@@ -59,7 +60,8 @@ func (fr *FakeReplicas) Create(replica *client.Replica) (result *client.Replica,
 	return res, err
 }
 
-func (fr *FakeReplicas) Update(replica *client.Replica) (result *client.Replica, err error) {
+// Update updates Replica object stored in the fake k8s
+func (fr *fakeReplicas) Update(replica *client.Replica) (result *client.Replica, err error) {
 	obj, err := fr.fake.
 		Invokes(testing.NewUpdateAction(replicaResource, fr.ns, replica), &client.Replica{})
 
@@ -69,31 +71,16 @@ func (fr *FakeReplicas) Update(replica *client.Replica) (result *client.Replica,
 	return obj.(*client.Replica), err
 }
 
-func (fr *FakeReplicas) Delete(name string) error {
+// Delete deletes a replica object by its name
+func (fr *fakeReplicas) Delete(name string) error {
 	_, err := fr.fake.
 		Invokes(testing.NewDeleteAction(replicaResource, fr.ns, name), &client.Replica{})
 
 	return err
 }
 
-func (fr *FakeReplicas) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(replicaResource, fr.ns, listOptions)
-
-	_, err := fr.fake.Invokes(action, &client.Replica{})
-	return err
-}
-
-func (fr *FakeReplicas) Get(name string) (result *client.Replica, err error) {
-	obj, err := fr.fake.
-		Invokes(testing.NewGetAction(replicaResource, fr.ns, name), &client.Replica{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*client.Replica), err
-}
-
-func (fr *FakeReplicas) List(opts api.ListOptions) (result *client.ReplicaList, err error) {
+// List returns a list of flow replicas stored in fake k8s
+func (fr *fakeReplicas) List(opts api.ListOptions) (result *client.ReplicaList, err error) {
 	obj, err := fr.fake.
 		Invokes(testing.NewListAction(replicaResource, fr.ns, opts), &client.ReplicaList{})
 

--- a/pkg/mocks/fake_resdefs.go
+++ b/pkg/mocks/fake_resdefs.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// FakeResDef implements ResourceDefinitionsInterface
-type FakeResDef struct {
+// fakeResDef implements ResourceDefinitionsInterface
+type fakeResDef struct {
 	fake *testing.Fake
 	ns   string
 }
@@ -35,7 +35,8 @@ var resdefResource = unversioned.GroupVersionResource{
 	Resource: "definitions",
 }
 
-func (c *FakeResDef) Create(resDef *client.ResourceDefinition) (result *client.ResourceDefinition, err error) {
+// Create creates new Definition object in fake K8s
+func (c *fakeResDef) Create(resDef *client.ResourceDefinition) (result *client.ResourceDefinition, err error) {
 	obj, err := c.fake.
 		Invokes(testing.NewCreateAction(resdefResource, c.ns, resDef), &client.ResourceDefinition{})
 
@@ -45,41 +46,16 @@ func (c *FakeResDef) Create(resDef *client.ResourceDefinition) (result *client.R
 	return obj.(*client.ResourceDefinition), err
 }
 
-func (c *FakeResDef) Update(resDef *client.ResourceDefinition) (result *client.ResourceDefinition, err error) {
-	obj, err := c.fake.
-		Invokes(testing.NewUpdateAction(resdefResource, c.ns, resDef), &client.ResourceDefinition{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*client.ResourceDefinition), err
-}
-
-func (c *FakeResDef) Delete(name string, options *api.DeleteOptions) error {
+// Delete deletes Definition object from fake K8s
+func (c *fakeResDef) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.fake.
 		Invokes(testing.NewDeleteAction(resdefResource, c.ns, name), &client.ResourceDefinition{})
 
 	return err
 }
 
-func (c *FakeResDef) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(resdefResource, c.ns, listOptions)
-
-	_, err := c.fake.Invokes(action, &client.ResourceDefinitionList{})
-	return err
-}
-
-func (c *FakeResDef) Get(name string) (result *client.ResourceDefinition, err error) {
-	obj, err := c.fake.
-		Invokes(testing.NewGetAction(resdefResource, c.ns, name), &client.ResourceDefinition{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*client.ResourceDefinition), err
-}
-
-func (c *FakeResDef) List(opts api.ListOptions) (result *client.ResourceDefinitionList, err error) {
+// List returns Definition objects stored in fake K8s
+func (c *fakeResDef) List(opts api.ListOptions) (result *client.ResourceDefinitionList, err error) {
 	obj, err := c.fake.
 		Invokes(testing.NewListAction(resdefResource, c.ns, opts), &client.ResourceDefinitionList{})
 

--- a/pkg/mocks/flows.go
+++ b/pkg/mocks/flows.go
@@ -16,6 +16,7 @@ package mocks
 
 import "github.com/Mirantis/k8s-AppController/pkg/client"
 
+// MakeFlow generates sample Flow resource definition
 func MakeFlow(name string) *client.ResourceDefinition {
 	flow := &client.Flow{
 		Exported:     true,
@@ -30,6 +31,7 @@ func MakeFlow(name string) *client.ResourceDefinition {
 	return &resDef
 }
 
+// MakeFlowParameter creates stample Flow parameter object
 func MakeFlowParameter(defaultValue string) client.FlowParameter {
 	return client.FlowParameter{Default: &defaultValue}
 }

--- a/pkg/mocks/jobs.go
+++ b/pkg/mocks/jobs.go
@@ -20,6 +20,7 @@ import (
 	batchapiv1 "k8s.io/client-go/pkg/apis/batch/v1"
 )
 
+// MakeJob generates sample Job object
 func MakeJob(name string) *batchapiv1.Job {
 	status := strings.Split(name, "-")[0]
 

--- a/pkg/mocks/pods.go
+++ b/pkg/mocks/pods.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+// MakePod generates sample Pod object
 func MakePod(name string) *v1.Pod {
 	status := strings.Split(name, "-")[0]
 	pod := &v1.Pod{}

--- a/pkg/mocks/replicasets.go
+++ b/pkg/mocks/replicasets.go
@@ -20,6 +20,7 @@ import (
 	extbeta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+// MakeReplicaSet generates sample ReplicaSet object
 func MakeReplicaSet(name string) *extbeta1.ReplicaSet {
 	status := strings.Split(name, "-")[0]
 

--- a/pkg/mocks/resdefs.go
+++ b/pkg/mocks/resdefs.go
@@ -23,13 +23,13 @@ import (
 	"k8s.io/client-go/pkg/api"
 )
 
+// MakeResourceDefinition generates sample ResourceDefinition object
 func MakeResourceDefinition(name string) *client.ResourceDefinition {
 	resName := normalizeName(name)
 
 	rd := &client.ResourceDefinition{
 		ObjectMeta: api.ObjectMeta{Name: resName, Namespace: "testing"},
 	}
-
 
 	splitted := strings.Split(name, "/")
 	objectType := splitted[0]

--- a/pkg/mocks/secrets.go
+++ b/pkg/mocks/secrets.go
@@ -16,6 +16,7 @@ package mocks
 
 import "k8s.io/client-go/pkg/api/v1"
 
+// MakeSecret generates sample Secret object
 func MakeSecret(name string) *v1.Secret {
 	secret := &v1.Secret{}
 	secret.Name = name

--- a/pkg/mocks/serviceaccounts.go
+++ b/pkg/mocks/serviceaccounts.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/pkg/runtime"
 )
 
+// MakeServiceAccount generates sample ServiceAccount object
 func MakeServiceAccount(name string) *v1.ServiceAccount {
 	serviceAccount := &v1.ServiceAccount{}
 	serviceAccount.Name = name
@@ -28,6 +29,7 @@ func MakeServiceAccount(name string) *v1.ServiceAccount {
 	return serviceAccount
 }
 
+// ServiceAccounts generates sample ServiceAccountList collection object
 func ServiceAccounts(names ...string) runtime.Object {
 	var serviceAccounts []v1.ServiceAccount
 	for i := 0; i < 3; i++ {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -21,7 +21,7 @@ import (
 	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 )
 
-const ReportIndentSize = 4
+const reportIndentSize = 4
 
 // NodeReport is a report of a node in graph
 type NodeReport struct {
@@ -52,7 +52,7 @@ func (n NodeReport) AsText(indent int) []string {
 		readyStr,
 	}
 	for _, dependency := range n.Dependencies {
-		ret = append(ret, dependencyReportAsText(dependency, ReportIndentSize)...)
+		ret = append(ret, dependencyReportAsText(dependency, reportIndentSize)...)
 	}
 	return Indent(indent, ret)
 }
@@ -64,7 +64,7 @@ type DeploymentReport []NodeReport
 func (d DeploymentReport) AsText(indent int) []string {
 	ret := make([]string, 0, len(d)*4)
 	for _, n := range d {
-		ret = append(ret, n.AsText(ReportIndentSize)...)
+		ret = append(ret, n.AsText(reportIndentSize)...)
 	}
 	return Indent(indent, ret)
 }

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -154,7 +154,7 @@ func podsStateFromLabels(apiClient client.Interface, objLabels map[string]string
 	resources := make([]interfaces.BaseResource, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		p := pod
-		resources = append(resources, newPod(&p, apiClient.Pods(), nil))
+		resources = append(resources, createNewPod(&p, apiClient.Pods(), nil))
 	}
 
 	status, err := resourceListStatus(resources)

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -29,13 +29,13 @@ var configMapParamFields = []string{
 	"Data.Keys",
 }
 
-type ConfigMap struct {
+type newConfigMap struct {
 	Base
 	ConfigMap *v1.ConfigMap
 	Client    corev1.ConfigMapInterface
 }
 
-type ExistingConfigMap struct {
+type existingConfigMap struct {
 	Base
 	Name   string
 	Client corev1.ConfigMapInterface
@@ -56,23 +56,23 @@ func (configMapTemplateFactory) Kind() string {
 	return "configmap"
 }
 
-// New returns ConfigMap controller for new resource based on resource definition
+// New returns configMap controller for new resource based on resource definition
 func (configMapTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	cm := parametrizeResource(def.ConfigMap, gc, configMapParamFields).(*v1.ConfigMap)
-	return report.SimpleReporter{BaseResource: ConfigMap{Base: Base{def.Meta}, ConfigMap: cm, Client: c.ConfigMaps()}}
+	return report.SimpleReporter{BaseResource: newConfigMap{Base: Base{def.Meta}, ConfigMap: cm, Client: c.ConfigMaps()}}
 }
 
-// NewExisting returns ConfigMap controller for existing resource by its name
+// NewExisting returns configMap controller for existing resource by its name
 func (configMapTemplateFactory) NewExisting(name string, ci client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ExistingConfigMap{Name: name, Client: ci.ConfigMaps()}}
+	return report.SimpleReporter{BaseResource: existingConfigMap{Name: name, Client: ci.ConfigMaps()}}
 }
 
 func configMapKey(name string) string {
 	return "configmap/" + name
 }
 
-// Key returns the ConfigMap object identifier
-func (c ConfigMap) Key() string {
+// Key returns the configMap object identifier
+func (c newConfigMap) Key() string {
 	return configMapKey(c.ConfigMap.Name)
 }
 
@@ -85,13 +85,13 @@ func configMapStatus(c corev1.ConfigMapInterface, name string) (interfaces.Resou
 	return interfaces.ResourceReady, nil
 }
 
-// Status returns ConfigMap status. interfaces.ResourceReady means that its dependencies can be created
-func (c ConfigMap) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+// Status returns configMap status. interfaces.ResourceReady means that its dependencies can be created
+func (c newConfigMap) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	return configMapStatus(c.Client, c.ConfigMap.Name)
 }
 
 // Create looks for DaemonSet in k8s and creates it if not present
-func (c ConfigMap) Create() error {
+func (c newConfigMap) Create() error {
 	if err := checkExistence(c); err != nil {
 		log.Println("Creating", c.Key())
 		c.ConfigMap, err = c.Client.Create(c.ConfigMap)
@@ -100,27 +100,27 @@ func (c ConfigMap) Create() error {
 	return nil
 }
 
-// Delete deletes ConfigMap from the cluster
-func (c ConfigMap) Delete() error {
+// Delete deletes configMap from the cluster
+func (c newConfigMap) Delete() error {
 	return c.Client.Delete(c.ConfigMap.Name, &v1.DeleteOptions{})
 }
 
-// Key returns the ConfigMap object identifier
-func (c ExistingConfigMap) Key() string {
+// Key returns the configMap object identifier
+func (c existingConfigMap) Key() string {
 	return configMapKey(c.Name)
 }
 
-// Status returns ConfigMap status. interfaces.ResourceReady means that its dependencies can be created
-func (c ExistingConfigMap) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+// Status returns configMap status. interfaces.ResourceReady means that its dependencies can be created
+func (c existingConfigMap) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	return configMapStatus(c.Client, c.Name)
 }
 
-// Create looks for existing ConfigMap and returns an error if there is no such ConfigMap in a cluster
-func (c ExistingConfigMap) Create() error {
+// Create looks for existing configMap and returns an error if there is no such configMap in a cluster
+func (c existingConfigMap) Create() error {
 	return createExistingResource(c)
 }
 
-// Delete deletes ConfigMap from the cluster
-func (c ExistingConfigMap) Delete() error {
+// Delete deletes configMap from the cluster
+func (c existingConfigMap) Delete() error {
 	return c.Client.Delete(c.Name, nil)
 }

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Mirantis/k8s-AppController/pkg/report"
 )
 
-type Flow struct {
+type flow struct {
 	Base
 	flow          *client.Flow
 	context       interfaces.GraphContext
@@ -59,7 +59,7 @@ func (flowTemplateFactory) New(def client.ResourceDefinition, c client.Interface
 	}
 
 	return report.SimpleReporter{
-		BaseResource: &Flow{
+		BaseResource: &flow{
 			Base:          Base{def.Meta},
 			flow:          newFlow,
 			context:       gc,
@@ -76,11 +76,11 @@ func (flowTemplateFactory) NewExisting(name string, c client.Interface, gc inter
 }
 
 // Key return Flow identifier
-func (f Flow) Key() string {
+func (f flow) Key() string {
 	return "flow/" + f.generatedName
 }
 
-func (f *Flow) buildDependencyGraph(replicaCount int, silent bool) (interfaces.DependencyGraph, error) {
+func (f *flow) buildDependencyGraph(replicaCount int, silent bool) (interfaces.DependencyGraph, error) {
 	args := map[string]string{}
 	for arg := range f.flow.Parameters {
 		val := f.context.GetArg(arg)
@@ -115,7 +115,7 @@ func (f *Flow) buildDependencyGraph(replicaCount int, silent bool) (interfaces.D
 // Create ensures that at least one flow replica exists. It will create first flow replica upon first call, but
 // all subsequent calls will do nothing but check the state of the resources from this replica (and recreate them,
 // if they were deleted manually between the calls), which makes Create() be idempotent
-func (f *Flow) Create() error {
+func (f *flow) Create() error {
 	graph := f.currentGraph
 
 	if graph == nil {
@@ -137,7 +137,7 @@ func (f *Flow) Create() error {
 // Note, that unlike Create() method Delete() is not idempotent. However, it doesn't create any issues since
 // Delete is called during dlow destruction which can happen only once while Create ensures that at least one flow
 // replica exists, and as such can be called any number of times
-func (f Flow) Delete() error {
+func (f flow) Delete() error {
 	graph, err := f.buildDependencyGraph(-1, false)
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func (f Flow) Delete() error {
 }
 
 // Status returns current status of the flow deployment
-func (f Flow) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+func (f flow) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	graph := f.currentGraph
 	if graph == nil {
 		var err error

--- a/pkg/resources/persistentvolumeclaim.go
+++ b/pkg/resources/persistentvolumeclaim.go
@@ -29,7 +29,7 @@ var persistentVolumeClaimParamFields = []string{
 	"Spec",
 }
 
-type PersistentVolumeClaim struct {
+type newPersistentVolumeClaim struct {
 	Base
 	PersistentVolumeClaim *v1.PersistentVolumeClaim
 	Client                corev1.PersistentVolumeClaimInterface
@@ -53,16 +53,16 @@ func (persistentVolumeClaimTemplateFactory) Kind() string {
 // New returns PVC controller for new resource based on resource definition
 func (persistentVolumeClaimTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	return report.SimpleReporter{
-		BaseResource: PersistentVolumeClaim{
+		BaseResource: newPersistentVolumeClaim{
 			Base: Base{def.Meta},
 			PersistentVolumeClaim: parametrizeResource(def.PersistentVolumeClaim, gc, persistentVolumeClaimParamFields).(*v1.PersistentVolumeClaim),
-			Client: c.PersistentVolumeClaims(),
+			Client:                c.PersistentVolumeClaims(),
 		}}
 }
 
 // NewExisting returns PVC controller for existing resource by its name
 func (persistentVolumeClaimTemplateFactory) NewExisting(name string, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ExistingPersistentVolumeClaim{Name: name, Client: c.PersistentVolumeClaims()}}
+	return report.SimpleReporter{BaseResource: existingPersistentVolumeClaim{Name: name, Client: c.PersistentVolumeClaims()}}
 }
 
 func persistentVolumeClaimKey(name string) string {
@@ -70,7 +70,7 @@ func persistentVolumeClaimKey(name string) string {
 }
 
 // Key returns the PersistentVolumeClaim object identifier
-func (p PersistentVolumeClaim) Key() string {
+func (p newPersistentVolumeClaim) Key() string {
 	return persistentVolumeClaimKey(p.PersistentVolumeClaim.Name)
 }
 
@@ -88,7 +88,7 @@ func persistentVolumeClaimStatus(p corev1.PersistentVolumeClaimInterface, name s
 }
 
 // Create looks for the PersistentVolumeClaim in k8s and creates it if not present
-func (p PersistentVolumeClaim) Create() error {
+func (p newPersistentVolumeClaim) Create() error {
 	if err := checkExistence(p); err != nil {
 		log.Println("Creating", p.Key())
 		p.PersistentVolumeClaim, err = p.Client.Create(p.PersistentVolumeClaim)
@@ -98,37 +98,37 @@ func (p PersistentVolumeClaim) Create() error {
 }
 
 // Delete deletes persistentVolumeClaim from the cluster
-func (p PersistentVolumeClaim) Delete() error {
+func (p newPersistentVolumeClaim) Delete() error {
 	return p.Client.Delete(p.PersistentVolumeClaim.Name, &v1.DeleteOptions{})
 }
 
 // Status returns PVC status.
-func (p PersistentVolumeClaim) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+func (p newPersistentVolumeClaim) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	return persistentVolumeClaimStatus(p.Client, p.PersistentVolumeClaim.Name)
 }
 
-type ExistingPersistentVolumeClaim struct {
+type existingPersistentVolumeClaim struct {
 	Base
 	Name   string
 	Client corev1.PersistentVolumeClaimInterface
 }
 
 // Key returns the PersistentVolumeClaim object identifier
-func (p ExistingPersistentVolumeClaim) Key() string {
+func (p existingPersistentVolumeClaim) Key() string {
 	return persistentVolumeClaimKey(p.Name)
 }
 
 // Create looks for existing PVC and returns error if there is no such PVC
-func (p ExistingPersistentVolumeClaim) Create() error {
+func (p existingPersistentVolumeClaim) Create() error {
 	return createExistingResource(p)
 }
 
 // Status returns PVC status.
-func (p ExistingPersistentVolumeClaim) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+func (p existingPersistentVolumeClaim) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	return persistentVolumeClaimStatus(p.Client, p.Name)
 }
 
 // Delete deletes persistentVolumeClaim from the cluster
-func (p ExistingPersistentVolumeClaim) Delete() error {
+func (p existingPersistentVolumeClaim) Delete() error {
 	return p.Client.Delete(p.Name, nil)
 }

--- a/pkg/resources/replicaset_test.go
+++ b/pkg/resources/replicaset_test.go
@@ -36,7 +36,7 @@ func TestSuccessCheck(t *testing.T) {
 
 func TestFailCheck(t *testing.T) {
 	c := mocks.NewClient(mocks.MakeReplicaSet("fail"))
-	status, err := replicaSetStatus(c.ReplicaSets(), "fail", map[string]string{SuccessFactorKey: "80"})
+	status, err := replicaSetStatus(c.ReplicaSets(), "fail", map[string]string{successFactorKey: "80"})
 
 	if err != nil {
 		t.Error(err)

--- a/pkg/resources/secrets.go
+++ b/pkg/resources/secrets.go
@@ -30,13 +30,13 @@ var secretParamFields = []string{
 	"StringData.Keys",
 }
 
-type Secret struct {
+type newSecret struct {
 	Base
 	Secret *v1.Secret
 	Client corev1.SecretInterface
 }
 
-type ExistingSecret struct {
+type existingSecret struct {
 	Base
 	Name   string
 	Client corev1.SecretInterface
@@ -60,12 +60,12 @@ func (secretTemplateFactory) Kind() string {
 // New returns Secret controller for new resource based on resource definition
 func (secretTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	secret := parametrizeResource(def.Secret, gc, secretParamFields).(*v1.Secret)
-	return report.SimpleReporter{BaseResource: Secret{Base: Base{def.Meta}, Secret: secret, Client: c.Secrets()}}
+	return report.SimpleReporter{BaseResource: newSecret{Base: Base{def.Meta}, Secret: secret, Client: c.Secrets()}}
 }
 
 // NewExisting returns Secret controller for existing resource by its name
 func (secretTemplateFactory) NewExisting(name string, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ExistingSecret{Name: name, Client: c.Secrets()}}
+	return report.SimpleReporter{BaseResource: existingSecret{Name: name, Client: c.Secrets()}}
 }
 
 func secretKey(name string) string {
@@ -73,12 +73,12 @@ func secretKey(name string) string {
 }
 
 // Key returns the Secret object identifier
-func (s Secret) Key() string {
+func (s newSecret) Key() string {
 	return secretKey(s.Secret.Name)
 }
 
 // Key returns the Secret object identifier
-func (s ExistingSecret) Key() string {
+func (s existingSecret) Key() string {
 	return secretKey(s.Name)
 }
 
@@ -92,12 +92,12 @@ func secretStatus(s corev1.SecretInterface, name string) (interfaces.ResourceSta
 }
 
 // Status returns interfaces.ResourceReady if the secret is available in cluster
-func (s Secret) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+func (s newSecret) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	return secretStatus(s.Client, s.Secret.Name)
 }
 
 // Create looks for the Secret in k8s and creates it if not present
-func (s Secret) Create() error {
+func (s newSecret) Create() error {
 	if err := checkExistence(s); err != nil {
 		log.Println("Creating", s.Key())
 		s.Secret, err = s.Client.Create(s.Secret)
@@ -107,21 +107,21 @@ func (s Secret) Create() error {
 }
 
 // Delete deletes Secret from the cluster
-func (s Secret) Delete() error {
+func (s newSecret) Delete() error {
 	return s.Client.Delete(s.Secret.Name, nil)
 }
 
 // Status returns interfaces.ResourceReady if the secret is available in cluster
-func (s ExistingSecret) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+func (s existingSecret) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	return secretStatus(s.Client, s.Name)
 }
 
 // Create looks for existing Secret and returns error if there is no such Secret
-func (s ExistingSecret) Create() error {
+func (s existingSecret) Create() error {
 	return createExistingResource(s)
 }
 
 // Delete deletes Secret from the cluster
-func (s ExistingSecret) Delete() error {
+func (s existingSecret) Delete() error {
 	return s.Client.Delete(s.Name, nil)
 }

--- a/pkg/resources/serviceaccount.go
+++ b/pkg/resources/serviceaccount.go
@@ -30,13 +30,13 @@ var serviceAccountParamFields = []string{
 	"ImagePullSecrets",
 }
 
-type ServiceAccount struct {
+type newServiceAccount struct {
 	Base
 	ServiceAccount *v1.ServiceAccount
 	Client         corev1.ServiceAccountInterface
 }
 
-type ExistingServiceAccount struct {
+type existingServiceAccount struct {
 	Base
 	Name   string
 	Client corev1.ServiceAccountInterface
@@ -61,13 +61,13 @@ func (serviceAccountTemplateFactory) Kind() string {
 func (serviceAccountTemplateFactory) New(def client.ResourceDefinition, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
 	serviceAccount := parametrizeResource(def.ServiceAccount, gc, serviceAccountParamFields).(*v1.ServiceAccount)
 	return report.SimpleReporter{
-		BaseResource: ServiceAccount{Base: Base{def.Meta}, ServiceAccount: serviceAccount, Client: c.ServiceAccounts()},
+		BaseResource: newServiceAccount{Base: Base{def.Meta}, ServiceAccount: serviceAccount, Client: c.ServiceAccounts()},
 	}
 }
 
 // NewExisting returns ServiceAccount controller for existing resource by its name
 func (serviceAccountTemplateFactory) NewExisting(name string, c client.Interface, gc interfaces.GraphContext) interfaces.Resource {
-	return report.SimpleReporter{BaseResource: ExistingServiceAccount{Name: name, Client: c.ServiceAccounts()}}
+	return report.SimpleReporter{BaseResource: existingServiceAccount{Name: name, Client: c.ServiceAccounts()}}
 }
 
 func serviceAccountKey(name string) string {
@@ -75,7 +75,7 @@ func serviceAccountKey(name string) string {
 }
 
 // Key returns ServiceAccount name
-func (c ServiceAccount) Key() string {
+func (c newServiceAccount) Key() string {
 	return serviceAccountKey(c.ServiceAccount.Name)
 }
 
@@ -89,12 +89,12 @@ func serviceAccountStatus(c corev1.ServiceAccountInterface, name string) (interf
 }
 
 // Status returns ServiceAccount status
-func (c ServiceAccount) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+func (c newServiceAccount) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	return serviceAccountStatus(c.Client, c.ServiceAccount.Name)
 }
 
 // Create looks for the ServiceAccount in k8s and creates it if not present
-func (c ServiceAccount) Create() error {
+func (c newServiceAccount) Create() error {
 	if err := checkExistence(c); err != nil {
 		log.Println("Creating", c.Key())
 		c.ServiceAccount, err = c.Client.Create(c.ServiceAccount)
@@ -104,26 +104,26 @@ func (c ServiceAccount) Create() error {
 }
 
 // Delete deletes ServiceAccount from the cluster
-func (c ServiceAccount) Delete() error {
+func (c newServiceAccount) Delete() error {
 	return c.Client.Delete(c.ServiceAccount.Name, &v1.DeleteOptions{})
 }
 
 // Key returns ServiceAccount name
-func (c ExistingServiceAccount) Key() string {
+func (c existingServiceAccount) Key() string {
 	return serviceAccountKey(c.Name)
 }
 
 // Status returns ServiceAccount status
-func (c ExistingServiceAccount) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
+func (c existingServiceAccount) Status(meta map[string]string) (interfaces.ResourceStatus, error) {
 	return serviceAccountStatus(c.Client, c.Name)
 }
 
 // Create looks for existing ServiceAccount and returns error if there is no such ServiceAccount
-func (c ExistingServiceAccount) Create() error {
+func (c existingServiceAccount) Create() error {
 	return createExistingResource(c)
 }
 
 // Delete deletes ServiceAccount from the cluster
-func (c ExistingServiceAccount) Delete() error {
+func (c existingServiceAccount) Delete() error {
 	return c.Client.Delete(c.Name, nil)
 }

--- a/pkg/scheduler/controller.go
+++ b/pkg/scheduler/controller.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// ProcessDeploymentTasks picks deployment tasks (ConfigMap objects) one by one in chronological order,
+// ProcessDeploymentTasks picks deployment tasks (configMap objects) one by one in chronological order,
 // restores graph options from it and deploys the graph. This is the main function of long-running deployment process
 func ProcessDeploymentTasks(client client.Interface, stopChan <-chan struct{}) {
 	added := make(chan *v1.ConfigMap)

--- a/pkg/scheduler/dependency_analyzer.go
+++ b/pkg/scheduler/dependency_analyzer.go
@@ -147,6 +147,7 @@ func assignVertex(vertex, root string, assigned map[string]bool, components map[
 	}
 }
 
+// EnsureNoCycles ensures that dependency graph has no cycles
 func EnsureNoCycles(dependencies []client.Dependency, resdefs map[string]client.ResourceDefinition) error {
 	flows := map[string]*client.Flow{}
 	if _, found := resdefs["flow/"+interfaces.DefaultFlowName]; !found {

--- a/pkg/scheduler/dependency_graph_test.go
+++ b/pkg/scheduler/dependency_graph_test.go
@@ -27,7 +27,7 @@ import (
 func TestAllocateReplicas(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
-	sched := New(c, nil, 0).(*Scheduler)
+	sched := New(c, nil, 0).(*scheduler)
 	newReplicas1, deleteReplicas, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3}))
 	if err != nil {
@@ -97,7 +97,7 @@ func TestAllocateReplicas(t *testing.T) {
 func TestDeallocateReplicas(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
-	sched := New(c, nil, 0).(*Scheduler)
+	sched := New(c, nil, 0).(*scheduler)
 	newReplicas1, deleteReplicas1, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 5}))
 	if err != nil {
@@ -134,15 +134,15 @@ func TestDeallocateReplicas(t *testing.T) {
 	ensureReplicas(c, t, 0, 5)
 }
 
-func toContext(options interfaces.DependencyGraphOptions) *GraphContext {
-	return &GraphContext{graph: &DependencyGraph{graphOptions: options}}
+func toContext(options interfaces.DependencyGraphOptions) *graphContext {
+	return &graphContext{graph: &dependencyGraph{graphOptions: options}}
 }
 
 // TestAllocateReplicasMinMax tests replica allocation with min/max constraints applied
 func TestAllocateReplicasMinMax(t *testing.T) {
 	flow := mocks.MakeFlow("flow").Flow
 	c := mocks.NewClient()
-	sched := New(c, nil, 0).(*Scheduler)
+	sched := New(c, nil, 0).(*scheduler)
 	newReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3, MinReplicaCount: 5, MaxReplicaCount: 10}))
 	if err != nil {

--- a/pkg/scheduler/flows_test.go
+++ b/pkg/scheduler/flows_test.go
@@ -54,7 +54,7 @@ func TestFlowResourcesIdentified(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	graph := depGraph.(*DependencyGraph).graph
+	graph := depGraph.(*dependencyGraph).graph
 
 	expectedLength := 2
 	if len(graph) != expectedLength {
@@ -97,7 +97,7 @@ func TestTopLevelResourcesAssignedToDefaultFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	graph := depGraph.(*DependencyGraph).graph
+	graph := depGraph.(*dependencyGraph).graph
 
 	expectedLength := 2
 	if len(graph) != expectedLength {

--- a/pkg/scheduler/frontend.go
+++ b/pkg/scheduler/frontend.go
@@ -26,27 +26,29 @@ import (
 	"k8s.io/client-go/pkg/labels"
 )
 
-type Scheduler struct {
+type scheduler struct {
 	client      client.Interface
 	selector    labels.Selector
 	concurrency int
 }
+
+var _ interfaces.Scheduler = &scheduler{}
 
 // New creates and initializes instance of Scheduler
 func New(client client.Interface, selector labels.Selector, concurrency int) interfaces.Scheduler {
 	if selector == nil {
 		selector, _ = labels.Parse("")
 	}
-	return &Scheduler{
+	return &scheduler{
 		client:      client,
 		selector:    selector,
 		concurrency: concurrency,
 	}
 }
 
-// Serialize converts scheduler settings and DependencyGraphOptions into string map which can be saved in ConfigMap
+// Serialize converts scheduler settings and DependencyGraphOptions into string map which can be saved in configMap
 // object. Together is has all the information required to build and deploy dependency graph
-func (sched *Scheduler) Serialize(options interfaces.DependencyGraphOptions) map[string]string {
+func (sched *scheduler) Serialize(options interfaces.DependencyGraphOptions) map[string]string {
 	result := map[string]string{
 		"selector":                     sched.selector.String(),
 		"concurrency":                  strconv.Itoa(sched.concurrency),
@@ -134,8 +136,8 @@ func getSelector(cfg map[string]string, key string, out *labels.Selector) (err e
 	return err
 }
 
-// CreateDeployment creates deployment task (ConfigMap object) for standalone deployment process and returns its name/error
-func (sched *Scheduler) CreateDeployment(options interfaces.DependencyGraphOptions) (string, error) {
+// CreateDeployment creates deployment task (configMap object) for standalone deployment process and returns its name/error
+func (sched *scheduler) CreateDeployment(options interfaces.DependencyGraphOptions) (string, error) {
 	cm := &v1.ConfigMap{}
 	cm.Data = sched.Serialize(options)
 	cm.GenerateName = "appcontrollerdeployment-"


### PR DESCRIPTION
This fixes all gofmt and all golint warnings (except for copied
petsets package and dot imports):

* Missing docstrings were written
* Types that don't have to be exported were made private
* Some unused client/fake methods were removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/258)
<!-- Reviewable:end -->
