### PR TITLE
Use status cache for resource readiness probes

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -75,7 +75,7 @@ func (sr *ScheduledResource) RequestCreation(toCreate chan *ScheduledResource) b
 }
 
 func isResourceFinished(sr *ScheduledResource, ch chan error) bool {
-	status, err := sr.Resource.Status(nil)
+	status, err := sr.Status(nil)
 	if err != nil {
 		ch <- err
 		return true
@@ -186,7 +186,7 @@ func createResources(toCreate chan *ScheduledResource, finished chan string, ccL
 			log.Println("Deployment is not stopped, keep creating")
 		}
 		go func(r *ScheduledResource, finished chan string, ccLimiter chan struct{}) {
-			// Acquire sepmaphor
+			// Acquire semaphore
 			ccLimiter <- struct{}{}
 			defer func() {
 				<-ccLimiter


### PR DESCRIPTION
When deployment engine waits for resource to became ready,
it should use ScheduledResource.Status() rather than Status method of
the underlying resource. The difference is that for ScheduledResource,
the status may be cached or set externally. For example, this
happens when Wait() times out. Without this change, the goroutine
created by Wait() will not recognize it and will continue running and
querying resource status in endless loop until deployment ends

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/264)
<!-- Reviewable:end -->
