### PR TITLE
'void' pseudo resource type

### DIFF
--- a/examples/flows/create.sh
+++ b/examples/flows/create.sh
@@ -15,6 +15,6 @@ cat job2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_N
 cat pod.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 cat pod2.yaml | $KUBECTL_NAME exec -i k8s-appcontroller kubeac wrap | $KUBECTL_NAME create -f -
 
-$KUBECTL_NAME exec k8s-appcontroller run
+$KUBECTL_NAME exec k8s-appcontroller kubeac run
 
 $KUBECTL_NAME logs -f k8s-appcontroller

--- a/examples/flows/deps.yaml
+++ b/examples/flows/deps.yaml
@@ -3,7 +3,7 @@ kind: Dependency
 metadata:
   generateName: dependency-
 parent: flow/DEFAULT
-child: flow/test-flow
+child: flow/test-flow/$prefix$AC_NAME
 args:
   prefix: a
 ---
@@ -19,7 +19,7 @@ kind: Dependency
 metadata:
   generateName: dependency-
 parent: pod/test-pod
-child: flow/test-flow
+child: flow/test-flow/$prefix$AC_NAME
 args:
   prefix: b
 ---
@@ -27,9 +27,10 @@ apiVersion: appcontroller.k8s/v1alpha1
 kind: Dependency
 metadata:
   generateName: dependency-
-parent: flow/test-flow
+parent: flow/test-flow/$prefix$AC_NAME
 child: job/test-job
 ---
+
 apiVersion: appcontroller.k8s/v1alpha1
 kind: Dependency
 metadata:

--- a/pkg/client/flows.go
+++ b/pkg/client/flows.go
@@ -70,16 +70,21 @@ type FlowParameter struct {
 
 // Replica resource represents one instance of the replicated flow. Since the only difference between replicas is their
 // $AC_NAME value which is replica name this resource is only needed to generate unique name for each replica and make
-// those name persistent so that we could do CRD (CRUD without "U") on the list of replica names
+// those name persistent so that we could do CRUD on the list of replica names
 type Replica struct {
 	unversioned.TypeMeta `json:",inline"`
 
 	// Standard object metadata
 	api.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
+	// flow name
 	FlowName string `json:"flowName,omitempty"`
 
+	// replica-space name
 	ReplicaSpace string `json:"replicaSpace,omitempty"`
+
+	// AC sets this field to true after deployment of the dependency graph for this replica
+	Deployed bool `json:"deployed,omitempty"`
 }
 
 // ReplicaList is a list of replicas
@@ -97,6 +102,7 @@ type ReplicasInterface interface {
 	List(opts api.ListOptions) (*ReplicaList, error)
 	Create(replica *Replica) (*Replica, error)
 	Delete(name string) error
+	Update(replica *Replica) error
 }
 
 type replicas struct {
@@ -156,6 +162,17 @@ func (r *replicas) Delete(name string) error {
 		Name(name).
 		Do().
 		Error()
+}
+
+// Update persists object changes back to k8s
+func (r *replicas) Update(replica *Replica) error {
+	_, err := r.rc.Put().
+		Namespace(r.namespace).
+		Resource("replicas").
+		Name(replica.Name).
+		Body(replica).
+		DoRaw()
+	return err
 }
 
 // ReplicaName returns replica name (which then goes into $AC_NAME var) encoded in Replica k8s object name

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -82,7 +82,7 @@ type GraphContext interface {
 	Scheduler() Scheduler
 	GetArg(string) string
 	Graph() DependencyGraph
-	Dependencies() []client.Dependency
+	Dependency() *client.Dependency
 }
 
 // DependencyGraphOptions contains all the input required to build a dependency graph

--- a/pkg/mocks/fake_replicas.go
+++ b/pkg/mocks/fake_replicas.go
@@ -61,14 +61,11 @@ func (fr *fakeReplicas) Create(replica *client.Replica) (result *client.Replica,
 }
 
 // Update updates Replica object stored in the fake k8s
-func (fr *fakeReplicas) Update(replica *client.Replica) (result *client.Replica, err error) {
-	obj, err := fr.fake.
+func (fr *fakeReplicas) Update(replica *client.Replica) error {
+	_, err := fr.fake.
 		Invokes(testing.NewUpdateAction(replicaResource, fr.ns, replica), &client.Replica{})
 
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*client.Replica), err
+	return err
 }
 
 // Delete deletes a replica object by its name

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -44,6 +44,7 @@ func init() {
 		serviceTemplateFactory{},
 		serviceAccountTemplateFactory{},
 		statefulSetTemplateFactory{},
+		voidTemplateFactory{},
 	}
 	for _, factory := range factories {
 		KindToResourceTemplate[factory.Kind()] = factory

--- a/pkg/resources/flow.go
+++ b/pkg/resources/flow.go
@@ -91,6 +91,9 @@ func (f *flow) buildDependencyGraph(replicaCount int, silent bool) (interfaces.D
 	fixedNumberOfReplicas := false
 	if replicaCount > 0 {
 		fixedNumberOfReplicas = f.context.Graph().Options().FixedNumberOfReplicas
+	} else if replicaCount == 0 {
+		fixedNumberOfReplicas = true
+		replicaCount = -1
 	}
 	options := interfaces.DependencyGraphOptions{
 		FlowName:              f.originalName,

--- a/pkg/resources/void.go
+++ b/pkg/resources/void.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Mirantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"github.com/Mirantis/k8s-AppController/pkg/client"
+	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
+	"github.com/Mirantis/k8s-AppController/pkg/report"
+)
+
+type void struct {
+	Base
+	name string
+}
+
+type voidTemplateFactory struct{}
+
+// Returns wrapped resource name. Since void resource cannot be wrapped it is always empty string
+func (voidTemplateFactory) ShortName(_ client.ResourceDefinition) string {
+	return ""
+}
+
+// k8s resource kind that this fabric supports
+func (voidTemplateFactory) Kind() string {
+	return "void"
+}
+
+// New returns new void based on resource definition. Since void cannot be wrapped it is always nil
+func (voidTemplateFactory) New(_ client.ResourceDefinition, _ client.Interface, _ interfaces.GraphContext) interfaces.Resource {
+	return nil
+}
+
+// NewExisting returns new void with specified name
+func (voidTemplateFactory) NewExisting(name string, _ client.Interface, gc interfaces.GraphContext) interfaces.Resource {
+	name = parametrizeResource(name, gc, []string{"*"}).(string)
+	return report.SimpleReporter{BaseResource: void{name: name}}
+}
+
+// Key returns void name
+func (v void) Key() string {
+	return "void/" + v.name
+}
+
+// Status always returns "ready"
+func (void) Status(_ map[string]string) (interfaces.ResourceStatus, error) {
+	return interfaces.ResourceReady, nil
+}
+
+// Delete is a no-op method to create resource
+func (void) Create() error {
+	return nil
+}
+
+// Delete is a no-op method to delete resource
+func (void) Delete() error {
+	return nil
+}

--- a/pkg/scheduler/dependency_graph_test.go
+++ b/pkg/scheduler/dependency_graph_test.go
@@ -15,12 +15,12 @@
 package scheduler
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/Mirantis/k8s-AppController/pkg/client"
 	"github.com/Mirantis/k8s-AppController/pkg/interfaces"
 	"github.com/Mirantis/k8s-AppController/pkg/mocks"
+	"k8s.io/client-go/pkg/api"
 )
 
 // TestAllocateReplicas tests replica allocation in different configurations
@@ -41,6 +41,7 @@ func TestAllocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
 	ensureReplicas(c, t, 0, 3)
+	acknowledgeReplicas(c, t)
 
 	newReplicas2, deleteReplicas, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 1}))
@@ -55,6 +56,7 @@ func TestAllocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
 	ensureReplicas(c, t, 0, 4)
+	acknowledgeReplicas(c, t)
 
 	allReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 5, FixedNumberOfReplicas: true}))
@@ -69,9 +71,15 @@ func TestAllocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
 	ensureReplicas(c, t, 0, 5)
+	acknowledgeReplicas(c, t)
 
-	if !reflect.DeepEqual(newReplicas2[0], allReplicas[3]) || !reflect.DeepEqual(newReplicas1, allReplicas[:3]) {
+	if newReplicas2[0].Name != allReplicas[3].Name {
 		t.Error("replica list is not stable")
+	}
+	for i, r := range newReplicas1 {
+		if r.Name != allReplicas[i].Name {
+			t.Error("replica list is not stable")
+		}
 	}
 
 	allReplicas2, deleteReplicas, err := sched.allocateReplicas(flow,
@@ -88,8 +96,10 @@ func TestAllocateReplicas(t *testing.T) {
 	}
 	ensureReplicas(c, t, 0, 5)
 
-	if !reflect.DeepEqual(allReplicas, allReplicas2) {
-		t.Error("replica list is not stable")
+	for i, r := range allReplicas {
+		if r.Name != allReplicas2[i].Name {
+			t.Error("replica list is not stable")
+		}
 	}
 }
 
@@ -111,6 +121,7 @@ func TestDeallocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas1))
 	}
 	ensureReplicas(c, t, 0, 5)
+	acknowledgeReplicas(c, t)
 
 	newReplicas2, deleteReplicas2, err := sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: -2}))
@@ -125,10 +136,11 @@ func TestDeallocateReplicas(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas2))
 	}
 
-	if !reflect.DeepEqual(deleteReplicas2, newReplicas1[3:]) {
-		t.Error("last created replicas should have been scheduled for deletion")
+	for i, replica := range deleteReplicas2 {
+		if replica.Name != newReplicas1[3+i].Name {
+			t.Error("last created replicas should have been scheduled for deletion")
+		}
 	}
-
 	// allocateReplicas can only create new Replica objects in k8s, but not delete existing
 	// replicas can only be deleted when all the resources belonging to it are deleted which happens after deployment
 	ensureReplicas(c, t, 0, 5)
@@ -156,17 +168,19 @@ func TestAllocateReplicasMinMax(t *testing.T) {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
 	ensureReplicas(c, t, 0, 5)
+	acknowledgeReplicas(c, t)
 
 	newReplicas, deleteReplicas, _ = sched.allocateReplicas(flow,
-		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 9, MinReplicaCount: 5, MaxReplicaCount: 10}))
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 9, MinReplicaCount: 5, MaxReplicaCount: 11}))
 
-	if len(newReplicas) != 5 {
+	if len(newReplicas) != 6 {
 		t.Fatal("unexpected new replica count", len(newReplicas))
 	}
 	if len(deleteReplicas) != 0 {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
-	ensureReplicas(c, t, 0, 10)
+	ensureReplicas(c, t, 0, 11)
+	acknowledgeReplicas(c, t)
 
 	newReplicas, deleteReplicas, err = sched.allocateReplicas(flow,
 		toContext(interfaces.DependencyGraphOptions{ReplicaCount: -6, MinReplicaCount: 5, MaxReplicaCount: 10}))
@@ -177,10 +191,60 @@ func TestAllocateReplicasMinMax(t *testing.T) {
 	if len(newReplicas) != 0 {
 		t.Fatal("unexpected new replica count", len(newReplicas))
 	}
-	if len(deleteReplicas) != 5 {
+	if len(deleteReplicas) != 6 {
 		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
 	}
-	ensureReplicas(c, t, 0, 10)
+	ensureReplicas(c, t, 0, 11)
+}
+
+// TestRepeatRelativeReplicaAllocation tests that repeated allocation of the same relative amount of replica
+// creates replicas on the first call only
+func TestRepeatRelativeReplicaAllocation(t *testing.T) {
+	flow := mocks.MakeFlow("flow").Flow
+	c := mocks.NewClient()
+	sched := New(c, nil, 0).(*scheduler)
+	newReplicas, deleteReplicas, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(newReplicas) != 3 {
+		t.Fatal("unexpected new replica count", len(newReplicas))
+	}
+	if len(deleteReplicas) != 0 {
+		t.Fatal("unexpected doomed replica count", len(deleteReplicas))
+	}
+
+	newReplicas2, deleteReplicas2, err := sched.allocateReplicas(flow,
+		toContext(interfaces.DependencyGraphOptions{ReplicaCount: 3}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(deleteReplicas2) != 0 {
+		t.Fatal("unexpected doomed replica count", len(deleteReplicas2))
+	}
+	if len(newReplicas2) != 3 {
+		t.Fatal("unexpected new replica count", len(newReplicas2))
+	}
+	for i := range newReplicas {
+		if newReplicas[i].Name != newReplicas2[i].Name {
+			t.Errorf("replica list differs: %s != %s", newReplicas[i].Name, newReplicas2[i].Name)
+		}
+	}
+}
+
+func acknowledgeReplicas(c client.Interface, t *testing.T) {
+	iface := c.Replicas()
+	list, err := iface.List(api.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range list.Items {
+		r.Deployed = true
+		iface.Update(&r)
+	}
 }
 
 // TestDependencyToFlowMatching tests how AC identifies if dependency belongs to a given flow path or not

--- a/pkg/scheduler/flows_test.go
+++ b/pkg/scheduler/flows_test.go
@@ -609,7 +609,7 @@ func TestReplication(t *testing.T) {
 }
 
 // TestReplicationWithSharedResources tests that resource definitions that don't have evaluated parts in their name
-// are shared across all flow replics
+// are shared across all flow replicas
 func TestReplicationWithSharedResources(t *testing.T) {
 	replicaCount := 3
 	c := mocks.NewClient(
@@ -738,8 +738,8 @@ func TestCompositionFlowReplication(t *testing.T) {
 		mocks.MakeResourceDefinition("job/ready-flow2-2-$AC_NAME"),
 
 		mocks.MakeDependency("flow/flow1", "job/ready-flow1-1-$AC_NAME", "flow=flow1"),
-		mocks.MakeDependency("job/ready-flow1-1-$AC_NAME", "flow/flow2", "flow=flow1"),
-		mocks.MakeDependency("flow/flow2", "job/ready-flow1-2-$AC_NAME", "flow=flow1"),
+		mocks.MakeDependency("job/ready-flow1-1-$AC_NAME", "flow/flow2/$AC_NAME", "flow=flow1"),
+		mocks.MakeDependency("flow/flow2/$AC_NAME", "job/ready-flow1-2-$AC_NAME", "flow=flow1"),
 		mocks.MakeDependency("flow/flow2", "job/ready-flow2-1-$AC_NAME", "flow=flow2"),
 		mocks.MakeDependency("job/ready-flow2-1-$AC_NAME", "job/ready-flow2-2-$AC_NAME", "flow=flow2"),
 	)
@@ -847,7 +847,7 @@ func TestCompositeFlowDestruction(t *testing.T) {
 		mocks.MakeResourceDefinition("job/ready-b$AC_NAME"),
 		mocks.MakeResourceDefinition("job/ready-c$AC_NAME"),
 		mocks.MakeDependency("flow/flow1", "job/ready-a$AC_NAME", "flow=flow1"),
-		mocks.MakeDependency("job/ready-a$AC_NAME", "flow/flow2", "flow=flow1"),
+		mocks.MakeDependency("job/ready-a$AC_NAME", "flow/flow2/$AC_NAME", "flow=flow1"),
 		mocks.MakeDependency("flow/flow2", "job/ready-b$AC_NAME", "flow=flow2"),
 		mocks.MakeDependency("flow/flow2", "job/ready-c$AC_NAME", "flow=flow2"),
 	)
@@ -1173,5 +1173,157 @@ func TestDeploymentRecoveryForRelativeReplicaCount(t *testing.T) {
 		if !r.Deployed {
 			t.Error("all replica must be deployed after successful graph deployment")
 		}
+	}
+}
+
+// TestMultiParentFlow tests that flow objects, that depends on two other resources doesn't turn into two separate flows
+func TestMultiParentFlow(t *testing.T) {
+	c := mocks.NewClient(
+		mocks.MakeFlow("test"),
+		mocks.MakeResourceDefinition("job/ready-$AC_NAME-1"),
+		mocks.MakeResourceDefinition("job/ready-$AC_NAME-2"),
+		mocks.MakeResourceDefinition("job/ready-$AC_NAME-3"),
+		mocks.MakeDependency("job/ready-$AC_NAME-1", "flow/test"),
+		mocks.MakeDependency("job/ready-$AC_NAME-2", "flow/test"),
+		mocks.MakeDependency("flow/test", "job/ready-$AC_NAME-3", "flow=test"),
+	)
+	sched := New(c, nil, 0)
+	depGraph, err := sched.BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stopChan := make(chan struct{})
+	depGraph.Deploy(stopChan)
+
+	ensureReplicas(c, t, 5, 3)
+}
+
+// TestMultiParentFlowWithSuffix tests, how flow with name without variables can depend on 2 resource
+// and be triggered once per consuming flow replica rather than once per parent resource or just once
+func TestMultiParentFlowWithSuffix(t *testing.T) {
+	c := mocks.NewClient(
+		mocks.MakeFlow("test"),
+		mocks.MakeResourceDefinition("job/ready-$AC_NAME-1"),
+		mocks.MakeResourceDefinition("job/ready-$AC_NAME-2"),
+		mocks.MakeResourceDefinition("job/ready-$AC_NAME-3"),
+		mocks.MakeDependency("job/ready-$AC_NAME-1", "flow/test/$AC_NAME"),
+		mocks.MakeDependency("job/ready-$AC_NAME-2", "flow/test/$AC_NAME"),
+		mocks.MakeDependency("flow/test", "job/ready-$AC_NAME-3", "flow=test"),
+	)
+	sched := New(c, nil, 0)
+	depGraph, err := sched.BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stopChan := make(chan struct{})
+	depGraph.Deploy(stopChan)
+
+	ensureReplicas(c, t, 6, 4)
+}
+
+// TestMultipleFlowCalls tests, how the same flow an be called several times from different places of another flow
+func TestMultipleFlowCalls(t *testing.T) {
+	flow := mocks.MakeFlow("test")
+	flow.Flow.Parameters = map[string]client.FlowParameter{
+		"name": mocks.MakeFlowParameter(""),
+	}
+
+	dep1 := mocks.MakeDependency("job/ready-1", "flow/test/call-1")
+	dep1.Args = map[string]string{"name": "aaa"}
+	dep2 := mocks.MakeDependency("job/ready-2", "flow/test/call-2")
+	dep2.Args = map[string]string{"name": "bbb"}
+
+	c := mocks.NewClient(
+		flow,
+		mocks.MakeResourceDefinition("job/ready-1"),
+		mocks.MakeResourceDefinition("job/ready-2"),
+		mocks.MakeResourceDefinition("job/ready-$name"),
+		dep1,
+		mocks.MakeDependency("flow/test/call-1", "job/ready-2"),
+		dep2,
+		mocks.MakeDependency("flow/test", "job/ready-$name", "flow=test"),
+	)
+	sched := New(c, nil, 0)
+	depGraph, err := sched.BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stopChan := make(chan struct{})
+	depGraph.Deploy(stopChan)
+
+	jobs := ensureReplicas(c, t, 4, 3)
+	jobNames := map[string]bool{
+		"ready-1":   true,
+		"ready-2":   true,
+		"ready-aaa": true,
+		"ready-bbb": true,
+	}
+	for _, job := range jobs {
+		if !jobNames[job.Name] {
+			t.Error("found unexpected job", job.Name)
+		}
+		delete(jobNames, job.Name)
+	}
+
+	if len(jobNames) != 0 {
+		t.Errorf("not all jobs were created: %d jobs were not found", len(jobNames))
+	}
+}
+
+// TestMultipathParameterPassingWithSuffix tests that single parametrized flow that is reachable along two
+// paths with different parameter values is triggered twice despite flow name is not parametrized due to usage of suffix
+func TestMultipathParameterPassingWithSuffix(t *testing.T) {
+	flow := mocks.MakeFlow("test")
+	flow.Flow.Parameters = map[string]client.FlowParameter{
+		"arg": mocks.MakeFlowParameter(""),
+	}
+
+	dep1 := mocks.MakeDependency("job/ready", "flow/test/$arg")
+	dep1.Args = map[string]string{"arg": "x"}
+	dep2 := mocks.MakeDependency("job/ready", "flow/test/$arg")
+	dep2.Args = map[string]string{"arg": "y"}
+
+	c := mocks.NewClient(
+		mocks.MakeResourceDefinition("job/ready"),
+		dep1,
+		dep2,
+		flow,
+		mocks.MakeResourceDefinition("job/ready-$arg"),
+		mocks.MakeDependency("flow/test", "job/ready-$arg", "flow=test"),
+	)
+
+	depGraph, err := New(c, nil, 0).BuildDependencyGraph(
+		interfaces.DependencyGraphOptions{ReplicaCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stopChan := make(chan struct{})
+	depGraph.Deploy(stopChan)
+
+	jobs, err := c.Jobs().List(api_v1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobNames := map[string]bool{
+		"ready":   true,
+		"ready-x": true,
+		"ready-y": true,
+	}
+	for _, job := range jobs.Items {
+		if !jobNames[job.Name] {
+			t.Error("found unexpected job", job.Name)
+		}
+		delete(jobNames, job.Name)
+	}
+
+	if len(jobNames) != 0 {
+		t.Errorf("not all jobs were created: %d jobs were not found", len(jobNames))
 	}
 }

--- a/pkg/scheduler/frontend.go
+++ b/pkg/scheduler/frontend.go
@@ -190,11 +190,9 @@ func GetStatus(client client.Interface, selector labels.Selector,
 	if options.FlowName == "" {
 		options.FlowName = interfaces.DefaultFlowName
 	}
-	options.ReplicaCount = 0
+	options.ReplicaCount = -1
+	options.FixedNumberOfReplicas = true
 	options.Silent = true
-	options.FixedNumberOfReplicas = false
-	options.MinReplicaCount = 0
-	options.MaxReplicaCount = 0
 
 	if !silent {
 		log.Println("Getting status of flow", options.FlowName)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -225,7 +225,6 @@ func createResources(toCreate chan *ScheduledResource, finished chan string, ccL
 						req := r.context.graph.graph[reqKey]
 						go func(req *ScheduledResource, toCreate chan *ScheduledResource) {
 							ticker := time.NewTicker(CheckInterval)
-							log.Printf("Requesting creation of dependency %v", req.Key())
 							for {
 								select {
 								case <-stopChan:

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -45,10 +45,20 @@ type ScheduledResource struct {
 	context        *graphContext
 	usedInReplicas []string
 	status         interfaces.ResourceStatus
+	suffix         string
 	interfaces.Resource
 	// parentKey -> dependencyMetadata
 	Meta map[string]map[string]string
 	sync.RWMutex
+}
+
+// Key returns resource identifier with optional suffix
+func (sr *ScheduledResource) Key() string {
+	baseKey := sr.Resource.Key()
+	if sr.suffix == "" {
+		return baseKey
+	}
+	return baseKey + "/" + sr.suffix
 }
 
 // RequestCreation does not create a scheduled resource immediately, but updates status

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -344,7 +344,6 @@ func (depGraph dependencyGraph) Deploy(stopChan <-chan struct{}) {
 		}
 	}
 	if depGraph.finalizer != nil {
-		log.Print("Performing resource cleanup")
 		depGraph.finalizer()
 	}
 	// TODO Make sure every KO gets created eventually

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -331,7 +331,7 @@ func TestLimitConcurrency(t *testing.T) {
 			key := fmt.Sprintf("resource%d", i)
 			r := report.SimpleReporter{BaseResource: mocks.NewCountingResource(key, counter, time.Second/4)}
 			context := &graphContext{graph: depGraph}
-			sr := newScheduledResourceFor(r, context, false)
+			sr := newScheduledResourceFor(r, "", context, false)
 			depGraph.graph[sr.Key()] = sr
 		}
 		stopChan := make(chan struct{})
@@ -599,7 +599,7 @@ func TestWaitWithZeroTimeout(t *testing.T) {
 	graph := &dependencyGraph{graphOptions: options}
 	gc := &graphContext{graph: graph}
 	resource := resources.KindToResourceTemplate["pod"].New(resdef, mocks.NewClient(pod), gc)
-	sr := newScheduledResourceFor(resource, gc, false)
+	sr := newScheduledResourceFor(resource, "", gc, false)
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 


### PR DESCRIPTION
void resource type is a resource that does nothing and is always
ready. There is no Definition for void resources, but they can be
used in dependencies by specifying "void/something" (i.e. the syntax
to refer to external resources without Definition).

Here is why it is needed:
* void resources can be used to create sync points between flow
  replicas (see unit test in this commit. Similar technique is used
  in etcd app, but in absence of void, service resource was used
  instead)
* any vertex in the graph can be replaced by void/* without breaking
  dependencies. It can be used to exclude resource from the graph and
  keeping it structure
* can be used in functional tests similar to how mock resources are used
  in unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirantis/k8s-appcontroller/265)
<!-- Reviewable:end -->
